### PR TITLE
Add fswait

### DIFF
--- a/fswait.c
+++ b/fswait.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <CoreServices/CoreServices.h> 
+
+/* fswait.c
+ * 
+ * usage: ./fswait /some/directory[:/some/otherdirectory:...]
+ *
+ * compile me with something like: gcc fswait.c -framework CoreServices -o fswait
+ *
+ * adapted from the FSEvents api PDF
+*/
+
+extern char **environ;
+
+//fork a process when there's any change in watch file
+void callback( 
+    ConstFSEventStreamRef streamRef, 
+    void *clientCallBackInfo, 
+    size_t numEvents, 
+    void *eventPaths, 
+    const FSEventStreamEventFlags eventFlags[], 
+    const FSEventStreamEventId eventIds[]) 
+{ 
+ exit(0);
+} 
+ 
+//set up fsevents and callback
+int main(int argc, char **argv) {
+
+  if(argc != 2) {
+    fprintf(stderr, "You must specify a directory to watch\n");
+    exit(1);
+  }
+
+  CFStringRef mypath = CFStringCreateWithCString(NULL, argv[1], kCFStringEncodingUTF8); 
+  CFArrayRef pathsToWatch = CFStringCreateArrayBySeparatingStrings (NULL, mypath, CFSTR(":"));
+
+  void *callbackInfo = NULL; 
+  FSEventStreamRef stream; 
+  CFAbsoluteTime latency = 1.0;
+
+  stream = FSEventStreamCreate(NULL,
+    &callback,
+    callbackInfo,
+    pathsToWatch,
+    kFSEventStreamEventIdSinceNow,
+    latency,
+    kFSEventStreamCreateFlagNone
+  ); 
+
+  FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode); 
+  FSEventStreamStart(stream);
+  CFRunLoopRun();
+}


### PR DESCRIPTION
An adaptation of fswatch that quits as soon as a filesystem event is discovered, similar to inotifywait
