### PR TITLE
Add --include [regex] option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Alan Dipert <alan@dipert.org>
 Enrico M. Crisostomo <enrico.m.crisostomo@gmail.com>
 Marcelo Andrade <marcelo.andrade.r@gmail.com>
+Leo Baker-Hytch <l.bakerhytch@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Copyright (C) 2013, Alan Dipert <alan@dipert.org>
 Copyright (C) 2013, Marcelo Andrade <marcelo.andrade.r@gmail.com>
 Copyright (C) 2014, Enrico M. Crisostomo <enrico.m.crisostomo@gmail.com>
+Copyright (C) 2014, Leo Baker-Hytch <l.bakerhytch@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/fsevent_monitor.cpp
+++ b/fsevent_monitor.cpp
@@ -91,12 +91,9 @@ void fsevent_monitor::run()
 
   for (string path : paths)
   {
-    if (accept_path(path))
-    {
-      dirs.push_back(CFStringCreateWithCString(NULL,
-                                               path.c_str(),
-                                               kCFStringEncodingUTF8));
-    }
+    dirs.push_back(CFStringCreateWithCString(NULL,
+                                             path.c_str(),
+                                             kCFStringEncodingUTF8));
   }
 
   if (dirs.size() == 0) return;

--- a/fswatch.7
+++ b/fswatch.7
@@ -99,6 +99,11 @@ Show the help message.
 .It Fl i, -insensitive
 Use case insensitive regular expressions.
 
+.It Fl I, -include Ar regexp
+Include paths matching
+.Ar regexp .
+Multiple include filters can be specified using this option multiple times. 
+
 .It Fl k, -kqueue
 Use the kqueue monitor.
 This option is only available when more than one monitor is available, and one

--- a/monitor.h
+++ b/monitor.h
@@ -33,11 +33,14 @@ public:
   monitor(std::vector<std::string> paths, EVENT_CALLBACK callback);
   virtual ~monitor();
   void set_latency(double latency);
-  void set_recursive(bool recursive);
-  void set_exclude(const std::vector<std::string> &exclusions,
-                   bool case_sensitive = true,
-                   bool extended = false);
-  void set_follow_symlinks(bool follow);
+  void set_recursive(bool recursive = false);
+  void set_follow_symlinks(bool follow = false);
+#ifdef HAVE_REGCOMP
+  void set_case_insensitive(bool case_insensitive = false);
+  void set_extended(bool extended = false);
+  void set_exclude(const std::vector<std::string> &exclusions);
+  void set_include(const std::vector<std::string> &inclusions);
+#endif
 
   virtual void run() = 0;
 
@@ -54,7 +57,11 @@ protected:
 
 private:
 #ifdef HAVE_REGCOMP
+  regex_t compile_pattern(std::string pattern);
+
+  int regex_flags = 0;
   std::vector<regex_t> exclude_regex;
+  std::vector<regex_t> include_regex;
 #endif
 };
 


### PR DESCRIPTION
In order to keep backwards compatibility, the corresponding short option is `-I`, so as not to clash with `-i`, which is used to specify case insensitive regexes.
