### PR TITLE
fswatch-run can't run a command with arguments

### DIFF
--- a/scripts/fswatch-run
+++ b/scripts/fswatch-run
@@ -10,4 +10,4 @@ command -v xargs >/dev/null 2>&1 || {
     exit 2
 }
 
-fswatch -o "$1" | xargs -n1 -I{} "$2"
+fswatch -o "$1" | xargs -n1 -I{} $2


### PR DESCRIPTION
new `fswatch-run` looks nice. But current implementation doesn't work for a command with arguments.

```
$ fswatch-run . "echo Hello"
xargs: echo Hello: No such file or directory
```
