### PR TITLE
Support an option syntax of colon-separated directory like v0.0.2 for fswatch-run

### DIFF
--- a/scripts/fswatch-run
+++ b/scripts/fswatch-run
@@ -10,4 +10,4 @@ command -v xargs >/dev/null 2>&1 || {
     exit 2
 }
 
-fswatch -o "$1" | xargs -n1 -I{} $2
+fswatch -o `echo $1 | sed -e 's/:/ /g'` | xargs -n1 -I{} $2


### PR DESCRIPTION
In a current vesion, the following command means just the 'foo:bar' directory is watched (and there is no directory of such a name.)

```
$ fswatch-run foo:bar "echo hello"
```
