### PR TITLE
Fix --include vs. --exclude precedence

### DIFF
--- a/libfswatch/src/libfswatch/c++/monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/monitor.cpp
@@ -120,12 +120,24 @@ namespace fsw
   bool monitor::accept_path(const char *path)
   {
 #ifdef HAVE_REGCOMP
+    bool matched_exclude = false;
     for (auto &filter : filters)
     {
       if (::regexec(&filter.regex, path, 0, nullptr, 0) == 0)
       {
-        return filter.type == fsw_filter_type::filter_include;
+        if (filter.type == fsw_filter_type::filter_include)
+        {
+          return true;
+        }
+        else
+        {
+          matched_exclude = true;
+        }
       }
+    }
+    if (matched_exclude)
+    {
+      return false;
     }
 #endif
 


### PR DESCRIPTION
Behaviour when both `--include` and `--exclude` arguments were provided was not
correct, at least according to what's in the documentation:

> ... `fswatch` processes filters this way:
> • If a path matches an including filter, the path is accepted no matter any other filter.
> • If a path matches an excluding filter, the path is rejected.
> • If a path matches no filters, the path is accepted.

This commit fixes the method `monitor::accept_path` so that for a given path it
traverses through all filters and returns:

  - true if there was a matching include
  - false if there was not a matching include but there was a matching exclude
  - true otherwise