### PR TITLE
Attach additional data to C API monitor callbacks

### DIFF
--- a/libfswatch/src/libfswatch/c/cevent.h
+++ b/libfswatch/src/libfswatch/c/cevent.h
@@ -68,13 +68,14 @@ extern "C"
    * passed the following arguments:
    *   - events, a const pointer to an array of events of type const fsw_cevent.
    *   - event_num, the size of the *events array.
+   *   - data, optional persisted data for a callback.
    * 
    * The memory used by the fsw_cevent objects will be freed at the end of the
    * callback invocation.  A callback should copy such data instead of storing
    * a pointer to it.
    */
   typedef void (*FSW_CEVENT_CALLBACK)(fsw_cevent const * const events,
-    const unsigned int event_num);
+    const unsigned int event_num, void * data);
 
 #  ifdef __cplusplus
 }

--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -48,6 +48,7 @@ typedef struct FSW_SESSION
   bool recursive;
   bool follow_symlinks;
   vector<monitor_filter> filters;
+  void * data;
 #ifdef HAVE_CXX_MUTEX
   atomic<bool> running;
 #endif
@@ -99,6 +100,7 @@ typedef struct fsw_callback_context
 {
   FSW_HANDLE handle;
   FSW_CEVENT_CALLBACK callback;
+  void * data;
 } fsw_callback_context;
 
 void libfsw_cpp_callback_proxy(const std::vector<event> & events,
@@ -149,7 +151,7 @@ void libfsw_cpp_callback_proxy(const std::vector<event> & events,
   }
 
   // TODO manage C++ exceptions from C code
-  (*(context->callback))(cevents, events.size());
+  (*(context->callback))(cevents, events.size(), context->data);
 
   // Deallocate memory allocated by events.
   for (unsigned int i = 0; i < events.size(); ++i)
@@ -225,6 +227,7 @@ int create_monitor(const FSW_HANDLE handle, const fsw_monitor_type type)
     fsw_callback_context * context_ptr = new fsw_callback_context;
     context_ptr->callback = session->callback;
     context_ptr->handle = session->handle;
+    context_ptr->data = session->data;
 
     monitor * current_monitor = monitor::create_monitor(type,
                                                         session->paths,
@@ -266,7 +269,7 @@ int fsw_add_path(const FSW_HANDLE handle, const char * path)
   return fsw_set_last_error(FSW_OK);
 }
 
-int fsw_set_callback(const FSW_HANDLE handle, const FSW_CEVENT_CALLBACK callback)
+int fsw_set_callback(const FSW_HANDLE handle, const FSW_CEVENT_CALLBACK callback, void * data)
 {
   if (!callback)
     return fsw_set_last_error(int(FSW_ERR_INVALID_CALLBACK));
@@ -279,6 +282,7 @@ int fsw_set_callback(const FSW_HANDLE handle, const FSW_CEVENT_CALLBACK callback
     FSW_SESSION * session = get_session(handle);
 
     session->callback = callback;
+    session->data = data;
   }
   catch (int error)
   {

--- a/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/libfswatch/src/libfswatch/c/libfswatch.h
@@ -75,7 +75,8 @@ extern "C"
    * following signature:
    * 
    *     void c_process_events(fsw_cevent const * const events,
-   *                           const unsigned int event_num);
+   *                           const unsigned int event_num,
+   *                           void * data);
    * 
    * When a monitor receives change events satisfying all the session criteria,
    * the callback is invoked and passed a copy of the events.
@@ -111,7 +112,8 @@ extern "C"
    * See cevent.h for the definition of FSW_CEVENT_CALLBACK.
    */
   FSW_STATUS fsw_set_callback(const FSW_HANDLE handle,
-                              const FSW_CEVENT_CALLBACK callback);
+                              const FSW_CEVENT_CALLBACK callback,
+                              void * data);
 
   /*
    * Sets the latency of the monitor.  By default, the latency is set to 1 s.


### PR DESCRIPTION
I found myself needing to pass extra data on the C API callbacks. I think its useful in general, cause you can't always rely on global data in the callbacks.

I'm open to suggestions on how this should be named.