### PR TITLE
Allow build on Illumos

### DIFF
--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -20,6 +20,9 @@
 #include "gettext_defs.h"
 #include "inotify_monitor.hpp"
 #include <limits.h>
+#ifdef __sun
+#  define NAME_MAX         255    /* # chars in a file name */
+#endif
 #include <unistd.h>
 #include <stdio.h>
 #include <sstream>


### PR DESCRIPTION
 - `NAME_MAX` is not in `limits.h` on Illumos.

I'm really not sure where to target this.  I read `CONTRIBUTING.md` and picked develop as the closest thing to a hotfix branch for 1.6.0.  I hope that is is okay.

My commit it based on 1.6.0 to hopefully make integration easier.  It applies cleanly to both **master** and **develop**.

Let me know if I've done this wrong and I'll gladly retarget and create a new PR :)