### PR TITLE
Fixed headers for c compilation

### DIFF
--- a/libfswatch/src/libfswatch/c/cevent.h
+++ b/libfswatch/src/libfswatch/c/cevent.h
@@ -91,7 +91,7 @@ extern "C"
    * @return #FSW_OK if the functions succeeds, #FSW_ERR_UNKNOWN_VALUE
    * otherwise.
    */
-  FSW_STATUS fsw_get_event_flag_by_name(const char *name, fsw_event_flag *flag);
+  FSW_STATUS fsw_get_event_flag_by_name(const char *name, enum fsw_event_flag *flag);
 
   /**
    * @brief Get the name of an event flag.
@@ -102,7 +102,7 @@ extern "C"
    * @param[in] flag The event flag to look for.
    * @return The name of @p flag, or @c nullptr if it does not exist.
    */
-  char *fsw_get_event_flag_name(const fsw_event_flag flag);
+  char *fsw_get_event_flag_name(const enum fsw_event_flag flag);
 
   /**
    * A file change event is represented as an instance of this struct where:
@@ -115,7 +115,7 @@ extern "C"
   {
     char * path;
     time_t evt_time;
-    fsw_event_flag * flags;
+    enum fsw_event_flag * flags;
     unsigned int flags_num;
   } fsw_cevent;
 

--- a/libfswatch/src/libfswatch/c/cfilter.h
+++ b/libfswatch/src/libfswatch/c/cfilter.h
@@ -44,7 +44,7 @@ extern "C"
   typedef struct fsw_cmonitor_filter
   {
     char * text;
-    fsw_filter_type type;
+    enum fsw_filter_type type;
     bool case_sensitive;
     bool extended;
   } fsw_cmonitor_filter;
@@ -54,7 +54,7 @@ extern "C"
   */
   typedef struct fsw_event_type_filter
   {
-    fsw_event_flag flag;
+    enum fsw_event_flag flag;
   } fsw_event_type_filter;
 
 #  ifdef __cplusplus

--- a/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/libfswatch/src/libfswatch/c/libfswatch.h
@@ -99,7 +99,7 @@ extern "C"
    *
    * @see cmonitor.h for a list of all the available monitors.
    */
-  FSW_HANDLE fsw_init_session(const fsw_monitor_type type = system_default_monitor_type);
+  FSW_HANDLE fsw_init_session(const enum fsw_monitor_type type/* = system_default_monitor_type*/);
 
   /**
    * Adds a path to watch to the specified session.  At least one path must be


### PR DESCRIPTION
Hi there,

Just fixed the C headers compilation issues, these are the changes I propose. Now one of the issues dealt with a C++ default function argument.

```
FSW_HANDLE fsw_init_session(const enum fsw_monitor_type type/* = system_default_monitor_type*/);
```

In C there are no default arguments, therefore I believe tha C source sample code should be updated to reflect this. You can either make the selection up to the user of your library or fix it internally. I'm a user and I have no issue what so ever with setting the monitor_type before usage.

Secondly, when building a C program using the headers linkage should be against a dynamic library in order to find all missing C++ symbols i.e.

```
$ gcc -I /usr/local/include -o "fswatch_test" fswatch_test.c /usr/local/lib/libfswatch.dylib
```

Cheers,
John