### PR TITLE
Fix C99 compatibility in cevent.h

### DIFF
--- a/libfswatch/src/libfswatch/c/cevent.h
+++ b/libfswatch/src/libfswatch/c/cevent.h
@@ -79,7 +79,7 @@ extern "C"
     Overflow = (1 << 13)          /**< The event queue has overflowed. */
   };
 
-  extern fsw_event_flag FSW_ALL_EVENT_FLAGS[15];
+  extern enum fsw_event_flag FSW_ALL_EVENT_FLAGS[15];
 
   /**
    * @brief Get event flag by name.


### PR DESCRIPTION
Currently it causes compilation error when using clang:

```
/usr/local/include/libfswatch/c/cevent.h:82:10: error: must use 'enum' tag to refer to type 'fsw_event_flag'
  extern fsw_event_flag FSW_ALL_EVENT_FLAGS[15];
         ^
```