### PR TITLE
Fix session memory is not actually being freed

### DIFF
--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -758,6 +758,8 @@ FSW_STATUS fsw_destroy_session(const FSW_HANDLE handle)
       }
       delete session->monitor;
     }
+
+    delete session;
   }
   catch (int error)
   {


### PR DESCRIPTION
Just minor fix, i've noticed that session is never get cleaned up, thus this might be (barely, but still) a possible memory leak.