### PR TITLE
Fix several issues

### DIFF
--- a/libfswatch/src/libfswatch/c/cevent.h
+++ b/libfswatch/src/libfswatch/c/cevent.h
@@ -79,7 +79,7 @@ extern "C"
     Overflow = (1 << 13)          /**< The event queue has overflowed. */
   };
 
-  extern fsw_event_flag FSW_ALL_EVENT_FLAGS[15];
+  extern enum fsw_event_flag FSW_ALL_EVENT_FLAGS[15];
 
   /**
    * @brief Get event flag by name.

--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -681,7 +681,15 @@ FSW_STATUS fsw_start_monitor(const FSW_HANDLE handle)
     FSW_SESSION *session = get_session(handle);
 
     if (!session->monitor)
-      create_monitor(handle, session->type);
+    {
+      FSW_STATUS ret = create_monitor(handle, session->type);
+
+      if (ret != FSW_OK)
+        return fsw_set_last_error(ret);
+    }
+
+    if (session->monitor == nullptr) // create_monitor returned OK, but monitor were not created
+      return fsw_set_last_error(FSW_ERR_UNKNOWN_MONITOR_TYPE);
 
     if (session->monitor->is_running())
       return fsw_set_last_error(int(FSW_ERR_MONITOR_ALREADY_RUNNING));

--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -758,6 +758,8 @@ FSW_STATUS fsw_destroy_session(const FSW_HANDLE handle)
       }
       delete session->monitor;
     }
+
+    delete session;
   }
   catch (int error)
   {


### PR DESCRIPTION
I've decided to group several fixes into single PR, instead of having them separately.

- Fix `cevent.h` not being C99 compliant (C++ stuff leaking into C headers)
- Fix session struct not being destroyed.
Debatable change, might potentially break existing code. However documentation says: 
> Destroys an existing session and __invalidates its handle__.

- Fix segfault during `fsw_start_monitor` if there is errors inside `create_monitor` (for example callback is not set)