### PR TITLE
Fix stop sequence for FSEvents monitor

### DIFF
--- a/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
@@ -125,9 +125,7 @@ namespace fsw
     // Fire the event loop
     run_loop = CFRunLoopGetCurrent();
 
-#ifdef HAVE_CXX_MUTEX
-    run_loop_lock.unlock();
-#endif
+    // Loop Initialization
 
     FSW_ELOG(_("Scheduling stream with run loop...\n"));
     FSEventStreamScheduleWithRunLoop(stream,
@@ -137,8 +135,27 @@ namespace fsw
     FSW_ELOG(_("Starting event stream...\n"));
     FSEventStreamStart(stream);
 
+#ifdef HAVE_CXX_MUTEX
+    run_loop_lock.unlock();
+#endif
+
+    // Loop
+
     FSW_ELOG(_("Starting run loop...\n"));
     CFRunLoopRun();
+
+    // Deinitialization part
+
+    FSW_ELOG(_("Stopping event stream...\n"));
+    FSEventStreamStop(stream);
+
+    FSW_ELOG(_("Invalidating event stream...\n"));
+    FSEventStreamInvalidate(stream);
+
+    FSW_ELOG(_("Releasing event stream...\n"));
+    FSEventStreamRelease(stream);
+
+    stream = nullptr;
   }
 
   /*
@@ -151,18 +168,7 @@ namespace fsw
     FSW_ELOG(_("Stopping run loop...\n"));
     CFRunLoopStop(run_loop);
 
-    run_loop = nullptr;
-
-    FSW_ELOG(_("Stopping event stream...\n"));
-    FSEventStreamStop(stream);
-
-    FSW_ELOG(_("Invalidating event stream...\n"));
-    FSEventStreamInvalidate(stream);
-
-    FSW_ELOG(_("Releasing event stream...\n"));
-    FSEventStreamRelease(stream);
-
-    stream = nullptr;
+    run_loop = nullptr;    
   }
 
   static vector<fsw_event_flag> decode_flags(FSEventStreamEventFlags flag)


### PR DESCRIPTION
If you stop monitor right after starting it in a separate thread - it might result in `segfault` and warnings like these:

```
2017-11-23 23:42 ruby[9437] (FSEvents.framework) streamRef->cfRunLoopSourceRef != NULL || streamRef->event_source != NULL(): failed assertion: Must call FSEventStreamScheduleWithRunLoop() before calling FSEventStreamInvalidate()

2017-11-23 23:42 ruby[9437] (FSEvents.framework) streamRef->cfRunLoopSourceRef == NULL && streamRef->event_source == NULL(): failed assertion: FSEventStream was released (causing it to be deallocated) without calling FSEventStreamInvalidate()
```

Code to reproduce (slightly modified `test/src/fswatch_test.c`) https://gist.github.com/t3hk0d3/a37fa9ca515ad27bbb8b756120828587

Idea is to have FSEvents deinitialization logic on same thread as initialization, while `on_stop` should just interrupt (stop) runloop.

It doesn't change deinitialization itself, so it should be backward-compatible.

This seems to be proper solution for me from all aspects, so you won't need to put any sleep timers before stopping monitor :)