### PR TITLE
Make the build reproducible.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -286,6 +286,9 @@ AS_VAR_IF([use_docker], [yes],
 
 # Variables used in man files.
 MAN_DATE=$(date +'%B %d, %Y')
+if test -n "$SOURCE_DATE_EPOCH"; then
+  MAN_DATE=$(LC_ALL=C date --utc --date=@$SOURCE_DATE_EPOCH +'%B %d, %Y')
+fi
 FSWATCH=${PACKAGE_NAME}
 MAN_BUG_REPORT=${PACKAGE_BUGREPORT}
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that fswatch could not be built reproducibly.

This is because the manpage used the output of the date(1) cmd.

This has been filed in Debian as #882818 [1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/882818