### PR TITLE
Use kFSEventStreamCreateFlagNoDefer with FSEvents

### DIFF
--- a/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
@@ -117,7 +117,7 @@ namespace fsw
                                  pathsToWatch,
                                  kFSEventStreamEventIdSinceNow,
                                  latency,
-                                 kFSEventStreamCreateFlagFileEvents);
+                                 (kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer));
 
     if (!stream)
       throw libfsw_exception(_("Event stream could not be created."));


### PR DESCRIPTION
Increase responsiveness by using the [kFSEventStreamCreateFlagNoDefer flag](https://developer.apple.com/documentation/coreservices/1455376-fseventstreamcreateflags/kfseventstreamcreateflagnodefer?language=objc). This is especially valuable when using fswatch in single-event mode in a looping script (ex. listen for event, run command, repeat).