### PR TITLE
Integrate with pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,14 @@ AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([libfswatch/Makefile])
 AC_CONFIG_FILES([libfswatch/doc/doxygen/Makefile])
 AC_CONFIG_FILES([libfswatch/src/libfswatch/Makefile])
+AC_CONFIG_FILES([libfswatch/src/libfswatch/libfswatch.pc])
 AC_CONFIG_FILES([fswatch/Makefile fswatch/src/Makefile fswatch/doc/Makefile])
 AC_CONFIG_FILES([po/Makefile.in])
 AC_CONFIG_FILES([man/fswatch.7])
 AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_MACRO_DIR([m4])
+
+PKG_INSTALLDIR()
 
 # Compute the canonical target-system type variables
 AC_CANONICAL_TARGET

--- a/libfswatch/src/libfswatch/Makefile.am
+++ b/libfswatch/src/libfswatch/Makefile.am
@@ -13,6 +13,10 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libfswatch.pc
+
 LIBFSWATCH_API_VERSION = @AM_LIBFSWATCH_API_VERSION@
 
 # Prepare gettext-related symbols used by programs

--- a/libfswatch/src/libfswatch/libfswatch.pc.in
+++ b/libfswatch/src/libfswatch/libfswatch.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libfswatch
+Description: libfswatch
+URL: https://github.com/emcrisostomo/fswatch/tree/master/libfswatch
+Version: @VERSION@
+Requires:
+Libs: -L${libdir} -lfswatch
+Cflags: -I${includedir}


### PR DESCRIPTION
I wanted to get this to work with pkg-config because it makes it convenient to add `libfswatch` as a dependency to other automake based projects via `PKG_CHECK_MODULES`.

Since it works for my purposes now, I decided to make this PR in case you're interested in integrating this upstream ^^