### PR TITLE
Fix cmake build without automake

### DIFF
--- a/fswatch/src/CMakeLists.txt
+++ b/fswatch/src/CMakeLists.txt
@@ -1,10 +1,28 @@
-add_definitions(-DHAVE_CONFIG_H)
 set(SOURCE_FILES
         fswatch.cpp
         fswatch.hpp
-        gettext.h
-        ../../libfswatch_config.h)
+        gettext.h)
+
+# We'll need one global config file for both cmake and automake :P
+set(COMPILE_DEFINITIONS
+        -DPACKAGE="fswatch"
+        -DPACKAGE_NAME="fswatch"
+        -DPACKAGE_VERSION="1.14.0"
+        -DPACKAGE_STRING="fswatch 1.14.0"
+        -DPACKAGE_BUGREPORT="enrico.m.crisostomo@gmail.com"
+        -DPACKAGE_URL="https://github.com/emcrisostomo/fswatch")
+
+if (EXISTS ../libfswatch_config.h)
+    set(SOURCE_FILES
+            ${SOURCE_FILES}
+            ../../libfswatch_config.h)
+
+    set(COMPILE_DEFINITIONS
+            ${COMPILE_DEFINITIONS}
+            -DHAVE_CONFIG_H)
+endif ()
 
 add_executable(fswatch ${SOURCE_FILES})
 target_include_directories(fswatch PUBLIC ../.. .)
 target_link_libraries(fswatch LINK_PUBLIC libfswatch)
+target_compile_definitions(fswatch PRIVATE ${COMPILE_DEFINITIONS})

--- a/fswatch/src/fswatch.cpp
+++ b/fswatch/src/fswatch.cpp
@@ -18,6 +18,7 @@
 #endif
 #include "gettext.h"
 #include "fswatch.hpp"
+#include <unistd.h> // optarg
 #include <iostream>
 #include <string>
 #include <exception>

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -14,7 +14,6 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 include_directories(.. src/libfswatch)
-add_definitions(-DHAVE_CONFIG_H)
 
 set(LIB_SOURCE_FILES
         src/libfswatch/c/cevent.cpp
@@ -46,8 +45,19 @@ set(LIB_SOURCE_FILES
         src/libfswatch/c++/string/string_utils.cpp
         src/libfswatch/c++/string/string_utils.hpp
         src/libfswatch/gettext.h
-        src/libfswatch/gettext_defs.h
-        ../libfswatch_config.h)
+        src/libfswatch/gettext_defs.h)
+
+set(LIB_COMPILE_DEFINITIONS "")
+
+if (EXISTS ../libfswatch_config.h)
+    set(LIB_SOURCE_FILES
+            ${LIB_SOURCE_FILES}
+            ../libfswatch_config.h)
+
+    set(LIB_COMPILE_DEFINITIONS
+            ${LIB_COMPILE_DEFINITIONS}
+            -DHAVE_CONFIG_H)
+endif ()
 
 INCLUDE(CheckIncludeFiles)
 
@@ -81,6 +91,10 @@ endif (HAVE_PORT_H)
 if (WIN32)
     CHECK_INCLUDE_FILES(sys/cygwin.h HAVE_CYGWIN)
 
+    set(LIB_COMPILE_DEFINITIONS
+            ${LIB_COMPILE_DEFINITIONS}
+            -DHAVE_STRUCT_STAT_ST_MTIME)
+
     if (HAVE_CYGWIN)
         set(LIB_SOURCE_FILES
                 ${LIB_SOURCE_FILES}
@@ -98,10 +112,12 @@ if (WIN32)
                 src/libfswatch/c++/windows_monitor.hpp)
         add_definitions(-DHAVE_WINDOWS)
     endif (HAVE_CYGWIN)
-endif (WIN32)
-
-if (APPLE)
+elseif (APPLE)
     CHECK_INCLUDE_FILES(CoreServices/CoreServices.h HAVE_FSEVENTS_FILE_EVENTS)
+
+    set(LIB_COMPILE_DEFINITIONS
+            ${LIB_COMPILE_DEFINITIONS}
+            -DHAVE_STRUCT_STAT_ST_MTIME)
 
     if (HAVE_FSEVENTS_FILE_EVENTS)
         find_library(CORESERVICES_LIBRARY CoreServices)
@@ -113,8 +129,15 @@ if (APPLE)
                 src/libfswatch/c++/fsevents_monitor.hpp)
 
     endif (HAVE_FSEVENTS_FILE_EVENTS)
-endif (APPLE)
+
+    set(LIB_COMPILE_DEFINITIONS -DHAVE_STRUCT_STAT_ST_MTIMESPEC)
+else () # Other Unix I suppose
+    set(LIB_COMPILE_DEFINITIONS
+            ${LIB_COMPILE_DEFINITIONS}
+            -HAVE_STRUCT_STAT_ST_MTIMESPEC)
+endif ()
 
 add_library(libfswatch ${LIB_SOURCE_FILES})
 target_include_directories(libfswatch PUBLIC src)
 target_link_libraries(libfswatch ${CORESERVICES_LIBRARY})
+target_compile_definitions(libfswatch PRIVATE ${LIB_COMPILE_DEFINITIONS})

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,9 +1,20 @@
 include_directories(../.. .)
-add_definitions(-DHAVE_CONFIG_H)
 
 set(SOURCE_FILES
-        fswatch_test.c
-        ../../libfswatch_config.h)
+        fswatch_test.c)
+
+set(COMPILE_DEFINITIONS "")
+
+if (EXISTS ../libfswatch_config.h)
+    set(SOURCE_FILES
+            ${SOURCE_FILES}
+            ../../libfswatch_config.h)
+
+    set(COMPILE_DEFINITIONS
+            ${COMPILE_DEFINITIONS}
+            -DHAVE_CONFIG_H)
+endif ()
 
 add_executable(fswatch_test ${SOURCE_FILES})
 target_link_libraries(fswatch_test LINK_PUBLIC libfswatch)
+target_compile_definitions(fswatch_test PRIVATE ${COMPILE_DEFINITIONS})


### PR DESCRIPTION
I want to use this as a library by including it via cmake as a git submodule! I can't right now because of how fswatch configures stuff with cmake :( 

I wrote something [here](https://github.com/emcrisostomo/fswatch/issues/176#issuecomment-647162045) as to why a cmake build system would be helpful. I'd appeciate any feedback!