### PR TITLE
fix compile error on macOS

### DIFF
--- a/fswatch/src/fswatch.cpp
+++ b/fswatch/src/fswatch.cpp
@@ -278,7 +278,7 @@ static bool parse_event_filter(const char *optarg)
   }
 }
 
-static bool validate_latency(double latency)
+static bool validate_latency(double latency, const char *optarg)
 {
   if (latency == 0.0)
   {
@@ -594,7 +594,7 @@ static void parse_opts(int argc, char **argv)
     case 'l':
       lvalue = strtod(optarg, nullptr);
 
-      if (!validate_latency(lvalue))
+      if (!validate_latency(lvalue, optarg))
       {
         exit(FSW_EXIT_LATENCY);
       }


### PR DESCRIPTION
simple type mistake, only reproduct on macOS (?)
'optarg' is a global variable, can be used directly, 
but macOS choked on that , 
and I see all other functions passing a parameter instead the global variable, 
so here just add a function parameter.

Signed-off-by: yunh <haihai107@126.com>