### PR TITLE
Map InodeMetaMod event to 'Updated' on MacOS

### DIFF
--- a/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
@@ -50,7 +50,7 @@ namespace fsw
     flags.push_back({kFSEventStreamEventFlagUnmount, fsw_event_flag::PlatformSpecific});
     flags.push_back({kFSEventStreamEventFlagItemCreated, fsw_event_flag::Created});
     flags.push_back({kFSEventStreamEventFlagItemRemoved, fsw_event_flag::Removed});
-    flags.push_back({kFSEventStreamEventFlagItemInodeMetaMod, fsw_event_flag::PlatformSpecific});
+    flags.push_back({kFSEventStreamEventFlagItemInodeMetaMod, fsw_event_flag::Updated});
     flags.push_back({kFSEventStreamEventFlagItemRenamed, fsw_event_flag::Renamed});
     flags.push_back({kFSEventStreamEventFlagItemModified, fsw_event_flag::Updated});
     flags.push_back({kFSEventStreamEventFlagItemFinderInfoMod, fsw_event_flag::PlatformSpecific});


### PR DESCRIPTION
We have been using fswatch to identify when files in a directory are touched (contents or timestamp modified). On MacOS, file touch events sometimes result in an `fsw_event_flag::Updated` then `IsFile`, and sometimes a `PlatformSpecific` then `IsFile` event. This is difficult to distinguish from other platform specific events. So we changed the underlying MacOS event type InodeMetaMod to map to `fsw_event_flag::Updated` (`AttributeModified` might also be a good choice).