### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ set(PACKAGE_URL       "https://github.com/emcrisostomo/${PACKAGE}")
 set(LOCALEDIR         "${CMAKE_INSTALL_PREFIX}/share/locale" CACHE FILEPATH "locale dir")
 #@formatter:on
 
-set(CMAKE_CXX_STANDARD 11)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 
 # Add option to choose between shared and static libraries
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)

--- a/fswatch/src/fswatch.cpp
+++ b/fswatch/src/fswatch.cpp
@@ -243,15 +243,16 @@ static void close_monitor()
 
 extern "C" void close_handler(int signal)
 {
+  (void)signal;
   FSW_ELOG(_("Executing termination handler.\n"));
   close_monitor();
 }
 
-static bool parse_event_bitmask(const char *optarg)
+static bool parse_event_bitmask(const char *poptarg)
 {
   try
   {
-    auto bitmask = std::stoul(optarg, nullptr, 10);
+    auto bitmask = std::stoul(poptarg, nullptr, 10);
 
     for (const auto& item : FSW_ALL_EVENT_FLAGS)
     {
@@ -269,13 +270,13 @@ static bool parse_event_bitmask(const char *optarg)
   }
 }
 
-static bool parse_event_filter(const char *optarg)
+static bool parse_event_filter(const char *poptarg)
 {
-  if (parse_event_bitmask(optarg)) return true;
+  if (parse_event_bitmask(poptarg)) return true;
 
   try
   {
-    event_filters.push_back({event::get_event_flag_by_name(optarg)});
+    event_filters.push_back({event::get_event_flag_by_name(poptarg)});
     return true;
   }
   catch (const libfsw_exception& ex)
@@ -285,17 +286,17 @@ static bool parse_event_filter(const char *optarg)
   }
 }
 
-static bool validate_latency(double latency, const char *optarg)
+static bool validate_latency(double latency, const char *poptarg)
 {
   if (latency == 0.0)
   {
-    std::cerr << _("Invalid value: ") << optarg << std::endl;
+    std::cerr << _("Invalid value: ") << poptarg << std::endl;
     return false;
   }
 
   if (errno == ERANGE || latency == HUGE_VAL)
   {
-    std::cerr << _("Value out of range: ") << optarg << std::endl;
+    std::cerr << _("Value out of range: ") << poptarg << std::endl;
     return false;
   }
 
@@ -440,12 +441,12 @@ static void process_events(const std::vector<event>& events, void *)
     write_events(events);
 }
 
-static void start_monitor(int argc, char **argv, int optind)
+static void start_monitor(int argc, char **argv, int poptind)
 {
   // parsing paths
   std::vector<std::string> paths;
 
-  for (auto i = optind; i < argc; ++i)
+  for (auto i = poptind; i < argc; ++i)
   {
     std::string path(fsw_realpath(argv[i], nullptr));
 

--- a/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/libfswatch/src/libfswatch/c/libfswatch.h
@@ -90,7 +90,7 @@ extern "C"
    * returns FSW_OK, otherwise the initialization routine failed and the library
    * should not be usable.
    */
-  FSW_STATUS fsw_init_library();
+  FSW_STATUS fsw_init_library(void);
 
   /**
    * This function creates a new monitor session using the specified monitor
@@ -195,12 +195,12 @@ extern "C"
   /**
    * Gets the last error code.
    */
-  FSW_STATUS fsw_last_error();
+  FSW_STATUS fsw_last_error(void);
 
   /**
    * Check whether the verbose mode is active.
    */
-  bool fsw_is_verbose();
+  bool fsw_is_verbose(void);
 
   /**
    * Set the verbose mode.

--- a/test/src/fswatch_test.c
+++ b/test/src/fswatch_test.c
@@ -21,6 +21,8 @@ void my_callback(fsw_cevent const *const events,
                  const unsigned int event_num,
                  void *data)
 {
+  (void)events;
+  (void)data;
   printf("my_callback: %d\n", event_num);
 }
 
@@ -60,7 +62,7 @@ int main(int argc, char **argv)
   if (handle == NULL)
   {
     fsw_last_error();
-    printf("Invalid fswatch handle: %p\n", handle);
+    printf("Invalid fswatch handle: %p\n", (void*)handle);
     return 2;
   }
 


### PR DESCRIPTION
This PR fixes two minor issues:
 - If users want to build with a higher c++ standard than 11, do not fix `CMAKE_CXX_STANDARD` if it is already set
 - Fix a number of pedantic code warnings from clang 15