### PR TITLE
Fix pthread usage in CMake

### DIFF
--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -78,8 +78,8 @@ check_struct_has_member("struct stat" st_mtimespec sys/stat.h HAVE_STRUCT_STAT_S
 check_include_file_cxx(unordered_map HAVE_UNORDERED_MAP)
 check_include_file_cxx(unordered_set HAVE_UNORDERED_SET)
 
-find_library(PTHREAD_LIBRARY pthread)
-set(EXTRA_LIBS ${EXTRA_LIBS} ${PTHREAD_LIBRARY})
+find_package(Threads REQUIRED)
+set(EXTRA_LIBS ${EXTRA_LIBS} Threads::Threads)
 
 check_include_file_cxx(sys/inotify.h HAVE_SYS_INOTIFY_H)
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+find_package(Threads REQUIRED)
 set(SOURCE_FILES
         fswatch_test.c
         ${PROJECT_BINARY_DIR}/libfswatch/libfswatch_config.h)
@@ -20,4 +21,4 @@ set(SOURCE_FILES
 add_executable(fswatch_test ${SOURCE_FILES})
 target_include_directories(fswatch_test PRIVATE ../.. .)
 target_include_directories(fswatch_test PRIVATE ${PROJECT_BINARY_DIR})
-target_link_libraries(fswatch_test PUBLIC libfswatch)
+target_link_libraries(fswatch_test PUBLIC libfswatch Threads::Threads)


### PR DESCRIPTION
Rather than searching for -lpthread, use find_package(Threads) and use the imported target that it creates. Make sure to use threads in the test program as well.