### PR TITLE
docs: add references to Go bindings

### DIFF
--- a/README.libfswatch.md
+++ b/README.libfswatch.md
@@ -3,7 +3,7 @@ README
 
 `libfswatch` is a library that provides developers the functionality of
 `fswatch`, the main `libfswatch` frontend.  The library provides both C and C++
-bindings.
+bindings. [Go bindings](https://github.com/dunglas/go-fswatch) are also available.
 
 `libfswatch` provides the following [documentation]:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Table of Contents
 libfswatch
 ----------
 
-`fswatch` is a frontend of `libfswatch`, a library with C and C++ binding.  More
+`fswatch` is a frontend of `libfswatch`, a library with C, C++ and [Go](https://github.com/dunglas/go-fswatch) binding.  More
 information on `libfswatch` can be found [here][README.libfswatch.md]. 
 
 [README.libfswatch.md]: README.libfswatch.md

--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -97,6 +97,8 @@
  * between the C library functions operating on a monitoring session and the
  * methods of the `monitor` class.
  *
+ * Go bindings are also available at https://github.com/dunglas/go-fswatch
+ *
  * @section thread-safety Thread Safety
  *
  * The C++ API does not deal with thread safety explicitly.  Rather, it leaves


### PR DESCRIPTION
Hi,

Thank you for this amazing pice of code.

I've created `libfswatch` bindings for Go that expose all the library's features in an idiomatic way: https://github.com/dunglas/go-fswatch

This patch adds references to these bindings in the documentation. Feel free to close the PR if you don't want to add references to a third-party package (which would be completely understandable).

Cheers,