### PR TITLE
Refactor path handling for conditional symlink handling at all levels

### DIFF
--- a/libfswatch/src/libfswatch/c++/kqueue_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/kqueue_monitor.cpp
@@ -198,7 +198,7 @@ namespace fsw
 
       // TODO: C++17 doesn't provide a single, comparable, type to represent st_mode
       struct stat fd_stat;
-      if (!lstat_path(path, fd_stat)) return;
+      if (!stat_path(path, fd_stat, follow_symlinks)) return;
       if (!add_watch(path, fd_stat)) return;
       if (!recursive || !is_dir) return;
 

--- a/libfswatch/src/libfswatch/c++/path_utils.cpp
+++ b/libfswatch/src/libfswatch/c++/path_utils.cpp
@@ -63,6 +63,23 @@ namespace fsw
     return entries;
   }
 
+  bool stat_path(const std::string& path, struct stat& fd_stat, bool follow_symlink)
+  {
+    if (follow_symlink)
+    {
+      if (lstat(path.c_str(), &fd_stat) == 0)
+        return true;
+    }
+    else
+    {
+      if (stat(path.c_str(), &fd_stat) == 0)
+        return true;
+    }
+
+    fsw_logf_perror(_("Cannot stat %s"), path.c_str());
+    return false;
+  }
+
   bool stat_path(const std::string& path, struct stat& fd_stat)
   {
     if (stat(path.c_str(), &fd_stat) == 0)
@@ -70,7 +87,6 @@ namespace fsw
 
     fsw_logf_perror(_("Cannot stat %s"), path.c_str());
     return false;
-
   }
 
   bool lstat_path(const std::string& path, struct stat& fd_stat)

--- a/libfswatch/src/libfswatch/c++/path_utils.hpp
+++ b/libfswatch/src/libfswatch/c++/path_utils.hpp
@@ -69,5 +69,19 @@ namespace fsw
    * @return @c true if the function succeeds, @c false otherwise.
    */
   bool stat_path(const std::string& path, struct stat& fd_stat);
+
+  /**
+   * @brief Wraps a @c stat(path, fd_stat) call or a @c lstat(path, fd_stat)
+   * call, depending on the value of @p follow_symlink.  The function invokes
+   * @c perror() if it fails.
+   * 
+   * @param path The path to @c stat() or @c lstat().
+   * @param fd_stat The @c stat structure where @c stat() or @c lstat() writes
+   * its results.
+   * @param follow_symlink @c true if the function should call @c lstat(),
+   * @c false if it should call @c stat().
+   * @return @c true if the function succeeds, @c false otherwise.
+   */
+  bool stat_path(const std::string& path, struct stat& fd_stat, bool follow_symlink);
 }
 #endif  /* FSW_PATH_UTILS_H */

--- a/libfswatch/src/libfswatch/c++/poll_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/poll_monitor.cpp
@@ -137,7 +137,7 @@ namespace fsw
       // TODO: C++17 doesn't standardize access to ctime, so we need to keep
       // using lstat for now.
       struct stat fd_stat;
-      if (!lstat_path(path, fd_stat)) return;
+      if (!stat_path(path, fd_stat, follow_symlinks)) return;
 
       if (!add_path(path, fd_stat, fn)) return;
       if (!recursive) return;


### PR DESCRIPTION
As of current `fswatch`, the behaviour of `kqueue_monitor` and `poll_monitor` is such that the `--follow-links` option would be honored for root paths, but then symlinks would always be followed. With this change, `--follow-links` would be honored for symlinks at any depth into a file hierarchy