### PR TITLE
Issue 337: fswatch exists on non existing path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.19.0 LANGUAGES C CXX)
+project(fswatch VERSION 1.18.2 LANGUAGES C CXX)
 
 #@formatter:off
 set(PACKAGE           "${PROJECT_NAME}")
 set(PACKAGE_NAME      "${PACKAGE}")
-set(PACKAGE_VERSION   "${PROJECT_VERSION}-develop")
+set(PACKAGE_VERSION   "${PROJECT_VERSION}")
 set(PACKAGE_STRING    "${PACKAGE_NAME} ${PACKAGE_VERSION}")
 set(PACKAGE_AUTHOR    "enrico.m.crisostomo@gmail.com")
 set(PACKAGE_BUGREPORT "${PACKAGE_AUTHOR}")

--- a/fswatch/src/fswatch.cpp
+++ b/fswatch/src/fswatch.cpp
@@ -452,7 +452,7 @@ static void start_monitor(int argc, char **argv, int optind)
 
   for (auto i = optind; i < argc; ++i)
   {
-    std::string path = std::filesystem::canonical(argv[i]).string();
+    std::string path = std::filesystem::absolute(argv[i]).string();
 
     FSW_ELOGF(_("Adding path: %s\n"), path.c_str());
 

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.19.0-develop])
+m4_define([FSWATCH_VERSION], [1.18.2])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.19.0-develop])
+m4_define([LIBFSWATCH_VERSION], [1.18.2])
 m4_define([LIBFSWATCH_API_VERSION], [13:1:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-01-18 01:36+0100\n"
+"POT-Creation-Date: 2025-01-27 11:53+0100\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: English\n"
@@ -283,11 +283,11 @@ msgstr ""
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/event.cpp:82
+#: libfswatch/src/libfswatch/c++/event.cpp:83
 msgid "Unknown event type: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/event.cpp:112
+#: libfswatch/src/libfswatch/c++/event.cpp:114
 msgid "Unknown event type."
 msgstr ""
 
@@ -315,9 +315,9 @@ msgid "Cannot allocate memory"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:218
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -396,44 +396,44 @@ msgstr ""
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:252
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:258
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:344
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:350
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:431
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:449
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:166
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:169
 #, c-format
 msgid "Cannot open %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:271
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
 msgid "kqueue already running."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:278
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
 msgid "kqueue failed."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:304
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
 msgid "kevent returned -1, invalid event number."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:323
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
 msgid "Event with EV_ERROR"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Event queue overflow."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:384
+#: libfswatch/src/libfswatch/c++/monitor.cpp:381
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr ""
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Cannot lstat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:217
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
 msgid "Done scanning.\n"
 msgstr ""
 

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,10 +30,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.18.1\n"
+"Project-Id-Version: fswatch 1.18.2\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-01-18 01:36+0100\n"
-"PO-Revision-Date: 2025-01-18 01:36+0100\n"
+"POT-Creation-Date: 2025-01-27 11:53+0100\n"
+"PO-Revision-Date: 2025-01-27 11:53+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@boldquot\n"
@@ -316,11 +316,11 @@ msgstr "An error occurred and the program will be terminated.\n"
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "An unknown error occurred and the program will be terminated.\n"
 
-#: libfswatch/src/libfswatch/c++/event.cpp:82
+#: libfswatch/src/libfswatch/c++/event.cpp:83
 msgid "Unknown event type: "
 msgstr "Unknown event type: "
 
-#: libfswatch/src/libfswatch/c++/event.cpp:112
+#: libfswatch/src/libfswatch/c++/event.cpp:114
 msgid "Unknown event type."
 msgstr "Unknown event type."
 
@@ -348,9 +348,9 @@ msgid "Cannot allocate memory"
 msgstr "Cannot allocate memory"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:218
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
@@ -429,44 +429,44 @@ msgstr "Removing: "
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:252
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:258
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:344
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:350
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:431
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:449
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:166
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:169
 #, c-format
 msgid "Cannot open %s"
 msgstr "Cannot open %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:271
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
 msgid "kqueue already running."
 msgstr "kqueue already running."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:278
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
 msgid "kqueue failed."
 msgstr "kqueue failed."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:304
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent returned -1, invalid event number."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:323
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
 msgid "Event with EV_ERROR"
 msgstr "Event with EV_ERROR"
 
@@ -507,7 +507,7 @@ msgstr "Stopping the monitor.\n"
 msgid "Event queue overflow."
 msgstr "Event queue overflow."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:384
+#: libfswatch/src/libfswatch/c++/monitor.cpp:381
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notifying events #: %d.\n"
@@ -528,7 +528,7 @@ msgstr "Cannot stat %s"
 msgid "Cannot lstat %s"
 msgstr "Cannot lstat %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:217
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
 msgid "Done scanning.\n"
 msgstr "Done scanning.\n"
 

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,10 +27,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.18.1\n"
+"Project-Id-Version: fswatch 1.18.2\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-01-18 01:36+0100\n"
-"PO-Revision-Date: 2025-01-18 01:36+0100\n"
+"POT-Creation-Date: 2025-01-27 11:53+0100\n"
+"PO-Revision-Date: 2025-01-27 11:53+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@quot\n"
@@ -313,11 +313,11 @@ msgstr "An error occurred and the program will be terminated.\n"
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "An unknown error occurred and the program will be terminated.\n"
 
-#: libfswatch/src/libfswatch/c++/event.cpp:82
+#: libfswatch/src/libfswatch/c++/event.cpp:83
 msgid "Unknown event type: "
 msgstr "Unknown event type: "
 
-#: libfswatch/src/libfswatch/c++/event.cpp:112
+#: libfswatch/src/libfswatch/c++/event.cpp:114
 msgid "Unknown event type."
 msgstr "Unknown event type."
 
@@ -345,9 +345,9 @@ msgid "Cannot allocate memory"
 msgstr "Cannot allocate memory"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:218
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
@@ -426,44 +426,44 @@ msgstr "Removing: "
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:252
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:258
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:344
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:350
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:431
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:449
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:166
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:169
 #, c-format
 msgid "Cannot open %s"
 msgstr "Cannot open %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:271
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
 msgid "kqueue already running."
 msgstr "kqueue already running."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:278
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
 msgid "kqueue failed."
 msgstr "kqueue failed."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:304
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent returned -1, invalid event number."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:323
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
 msgid "Event with EV_ERROR"
 msgstr "Event with EV_ERROR"
 
@@ -504,7 +504,7 @@ msgstr "Stopping the monitor.\n"
 msgid "Event queue overflow."
 msgstr "Event queue overflow."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:384
+#: libfswatch/src/libfswatch/c++/monitor.cpp:381
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notifying events #: %d.\n"
@@ -525,7 +525,7 @@ msgstr "Cannot stat %s"
 msgid "Cannot lstat %s"
 msgstr "Cannot lstat %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:217
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
 msgid "Done scanning.\n"
 msgstr "Done scanning.\n"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-01-18 01:36+0100\n"
+"POT-Creation-Date: 2025-01-27 11:53+0100\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -294,11 +294,11 @@ msgstr "Ha ocurrido un error y el programa terminará.\n"
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "Ha ocurrido un error desconocido y el programa terminará.\n"
 
-#: libfswatch/src/libfswatch/c++/event.cpp:82
+#: libfswatch/src/libfswatch/c++/event.cpp:83
 msgid "Unknown event type: "
 msgstr "Tipo evento desconocido: "
 
-#: libfswatch/src/libfswatch/c++/event.cpp:112
+#: libfswatch/src/libfswatch/c++/event.cpp:114
 msgid "Unknown event type."
 msgstr "Tipo evento desconocido."
 
@@ -326,9 +326,9 @@ msgid "Cannot allocate memory"
 msgstr "No se puede reservar memoria"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:218
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -407,44 +407,44 @@ msgstr "Eliminando: "
 msgid "Added: "
 msgstr "Añadiendo: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:252
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:258
 msgid "Generic event: "
 msgstr "Evento genérico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:344
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:350
 msgid "Removed: "
 msgstr "Eliminado: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:431
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
 msgid "Number of records: "
 msgstr "Numero de registros: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sobre el descriptor inotify leyó 0 registros."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:449
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sobre le descriptor inotify devolvió -1."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:166
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:169
 #, c-format
 msgid "Cannot open %s"
 msgstr "No se puede abrir %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:271
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
 msgid "kqueue already running."
 msgstr "kqueue ya está ejecutándose."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:278
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
 msgid "kqueue failed."
 msgstr "kqueue falló."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:304
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent devolvió -1, numero de evento inválido."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:323
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
 msgid "Event with EV_ERROR"
 msgstr "Evento con EV_ERROR"
 
@@ -485,7 +485,7 @@ msgstr "Parando el monitor...\n"
 msgid "Event queue overflow."
 msgstr "Cola de eventos saturada."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:384
+#: libfswatch/src/libfswatch/c++/monitor.cpp:381
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notificando eventos #: %d.\n"
@@ -506,7 +506,7 @@ msgstr "No se puede hacer stat() de %s"
 msgid "Cannot lstat %s"
 msgstr "No se puede hacer lstat() de %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:217
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
 msgid "Done scanning.\n"
 msgstr "Rastreo terminado.\n"
 

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.18.1\n"
+"Project-Id-Version: fswatch 1.18.2\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-01-18 01:36+0100\n"
+"POT-Creation-Date: 2025-01-27 11:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -283,11 +283,11 @@ msgstr ""
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/event.cpp:82
+#: libfswatch/src/libfswatch/c++/event.cpp:83
 msgid "Unknown event type: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/event.cpp:112
+#: libfswatch/src/libfswatch/c++/event.cpp:114
 msgid "Unknown event type."
 msgstr ""
 
@@ -315,9 +315,9 @@ msgid "Cannot allocate memory"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:218
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -396,44 +396,44 @@ msgstr ""
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:252
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:258
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:344
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:350
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:431
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:449
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:166
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:169
 #, c-format
 msgid "Cannot open %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:271
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
 msgid "kqueue already running."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:278
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
 msgid "kqueue failed."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:304
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
 msgid "kevent returned -1, invalid event number."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:323
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
 msgid "Event with EV_ERROR"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Event queue overflow."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:384
+#: libfswatch/src/libfswatch/c++/monitor.cpp:381
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr ""
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Cannot lstat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:217
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
 msgid "Done scanning.\n"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-01-18 01:36+0100\n"
+"POT-Creation-Date: 2025-01-27 11:53+0100\n"
 "PO-Revision-Date: 2018-05-02 17:29+0200\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -294,11 +294,11 @@ msgstr "Errore, il programma sarà terminato.\n"
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "Errore sconosciuto, il programma sarà terminato.\n"
 
-#: libfswatch/src/libfswatch/c++/event.cpp:82
+#: libfswatch/src/libfswatch/c++/event.cpp:83
 msgid "Unknown event type: "
 msgstr "Tipo evento sconosciuto: "
 
-#: libfswatch/src/libfswatch/c++/event.cpp:112
+#: libfswatch/src/libfswatch/c++/event.cpp:114
 msgid "Unknown event type."
 msgstr "Tipo evento sconosciuto."
 
@@ -326,9 +326,9 @@ msgid "Cannot allocate memory"
 msgstr "Non si può allocare memoria"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:218
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -407,44 +407,44 @@ msgstr "Eliminando: "
 msgid "Added: "
 msgstr "Aggiunto: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:252
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:258
 msgid "Generic event: "
 msgstr "Evento generico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:344
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:350
 msgid "Removed: "
 msgstr "Eliminato: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:431
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
 msgid "Number of records: "
 msgstr "Numero di registri: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:437
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sul descrittore inotify ha trovato 0 registri."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:443
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:449
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sul descrittore inotify ha ritornato -1."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:166
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:169
 #, c-format
 msgid "Cannot open %s"
 msgstr "Non si può aprire %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:271
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
 msgid "kqueue already running."
 msgstr "Si sta già eseguando kqueue."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:278
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
 msgid "kqueue failed."
 msgstr "kqueue ha fallito."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:304
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent ha ritornato -1, numero di eventi invalido."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:323
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
 msgid "Event with EV_ERROR"
 msgstr "Evento con EV_ERROR"
 
@@ -485,7 +485,7 @@ msgstr "Fermando il monitor...\n"
 msgid "Event queue overflow."
 msgstr "La coda degli eventi è andata in overflow."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:384
+#: libfswatch/src/libfswatch/c++/monitor.cpp:381
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notificando eventi #: %d.\n"
@@ -506,7 +506,7 @@ msgstr "Non posso eseguire stat() di %s"
 msgid "Cannot lstat %s"
 msgstr "Non posso eseguire lstat() di %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:217
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
 msgid "Done scanning.\n"
 msgstr "Scansione terminata.\n"
 


### PR DESCRIPTION
Use std::filesystem::absolute instead of std::filesystem::canonical when passing path arguments to monitors