### PR TITLE
Fixes spurious output 'inotify_rm_watch: Invalid argument'

### DIFF
--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -86,20 +86,15 @@ namespace fsw
 
   inotify_monitor::~inotify_monitor()
   {
-    // close inotify watchers
+    // log removal of inotify watchers (automatically removed by close below)
     for (auto inotify_desc_pair : impl->watched_descriptors)
     {
       std::ostringstream log;
       log << _("Removing: ") << inotify_desc_pair << "\n";
       FSW_ELOG(log.str().c_str());
-
-      if (inotify_rm_watch(impl->inotify_monitor_handle, inotify_desc_pair))
-      {
-        perror("inotify_rm_watch");
-      }
     }
 
-    // close inotify
+    // close inotify (removes watches)
     if (impl->inotify_monitor_handle > 0)
     {
       close(impl->inotify_monitor_handle);


### PR DESCRIPTION
Fixes https://github.com/emcrisostomo/fswatch/issues/206

This PR removes the explicit calls to `inotify_rm_watch()` in the inotify monitor destructor as these are implicitly removed when the inotify handle is closed.

The logging of the removals is retained.

According to [`inotify(7)`](https://man7.org/linux/man-pages/man7/inotify.7.html):

> When all file descriptors referring to an inotify instance have
          been closed (using [close(2)](https://man7.org/linux/man-pages/man2/close.2.html)), the underlying object and its
          resources are freed for reuse by the kernel; all associated
          watches are automatically freed.

