### PR TITLE
Enable compilation of libfswatch under Windows MinGW

### DIFF
--- a/.github/workflows/cmake-libfswatch.yml
+++ b/.github/workflows/cmake-libfswatch.yml
@@ -1,0 +1,38 @@
+name: CMake libfswatch on Windows MinGW
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: r-lib/actions/setup-r@v2
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-libfswatch.yml
+++ b/.github/workflows/cmake-libfswatch.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_LIBS_ONLY
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake-libfswatch.yml
+++ b/.github/workflows/cmake-libfswatch.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_LIBS_ONLY
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_LIBS_ONLY=1
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Add option to choose between shared and static libraries
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+# Add option to build libfswatch only (without fswatch or tests)
+option(BUILD_LIBS_ONLY "Build libfswatch only" OFF)
 
 # include modules
 include(FindGettext)
@@ -74,5 +76,7 @@ if (USE_NLS)
 endif ()
 
 add_subdirectory(libfswatch)
+if (NOT BUILD_LIBS_ONLY)
 add_subdirectory(fswatch/src)
 add_subdirectory(test/src)
+endif ()

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -112,30 +112,28 @@ endif (HAVE_PORT_H)
 
 check_cxx_symbol_exists(FindFirstChangeNotification windows.h HAVE_WINDOWS_HEADER)
 
-if (HAVE_WINDOWS_HEADER AND CYGWIN)
-    check_include_file_cxx(sys/cygwin.h HAVE_CYGWIN)
+if (HAVE_WINDOWS_HEADER)
 
-    if (HAVE_CYGWIN)
-        set(LIBFSWATCH_HEADER_FILES
-                ${LIBFSWATCH_HEADER_FILES}
-                src/libfswatch/c++/windows/win_directory_change_event.hpp
-                src/libfswatch/c++/windows/win_error_message.hpp
-                src/libfswatch/c++/windows/win_handle.hpp
-                src/libfswatch/c++/windows/win_paths.hpp
-                src/libfswatch/c++/windows/win_strings.hpp
-                src/libfswatch/c++/windows_monitor.hpp)
+    set(LIBFSWATCH_HEADER_FILES
+            ${LIBFSWATCH_HEADER_FILES}
+            src/libfswatch/c++/windows/win_directory_change_event.hpp
+            src/libfswatch/c++/windows/win_error_message.hpp
+            src/libfswatch/c++/windows/win_handle.hpp
+            src/libfswatch/c++/windows/win_paths.hpp
+            src/libfswatch/c++/windows/win_strings.hpp
+            src/libfswatch/c++/windows_monitor.hpp)
 
-        set(LIB_SOURCE_FILES
-                ${LIB_SOURCE_FILES}
-                src/libfswatch/c++/windows/win_directory_change_event.cpp
-                src/libfswatch/c++/windows/win_error_message.cpp
-                src/libfswatch/c++/windows/win_handle.cpp
-                src/libfswatch/c++/windows/win_paths.cpp
-                src/libfswatch/c++/windows/win_strings.cpp
-                src/libfswatch/c++/windows_monitor.cpp)
-        set(HAVE_WINDOWS ON CACHE BOOL "Enable Windows support")
-    endif (HAVE_CYGWIN)
-endif (HAVE_WINDOWS_HEADER AND CYGWIN)
+    set(LIB_SOURCE_FILES
+            ${LIB_SOURCE_FILES}
+            src/libfswatch/c++/windows/win_directory_change_event.cpp
+            src/libfswatch/c++/windows/win_error_message.cpp
+            src/libfswatch/c++/windows/win_handle.cpp
+            src/libfswatch/c++/windows/win_paths.cpp
+            src/libfswatch/c++/windows/win_strings.cpp
+            src/libfswatch/c++/windows_monitor.cpp)
+    set(HAVE_WINDOWS ON CACHE BOOL "Enable Windows support")
+
+endif (HAVE_WINDOWS_HEADER)
 
 if (APPLE)
     check_include_file_cxx(CoreServices/CoreServices.h HAVE_FSEVENTS_FILE_EVENTS)

--- a/libfswatch/src/libfswatch/c++/path_utils.cpp
+++ b/libfswatch/src/libfswatch/c++/path_utils.cpp
@@ -33,17 +33,17 @@ namespace fsw
 
     try
     {
-      for (const auto& entry : std::filesystem::directory_iterator(path)) 
+      for (const auto& entry : std::filesystem::directory_iterator(path))
         entries.emplace_back(entry);
-    } 
-    catch (const std::filesystem::filesystem_error& e) 
+    }
+    catch (const std::filesystem::filesystem_error& e)
     {
       FSW_ELOGF(_("Error accessing directory: %s"), e.what());
     }
 
     return entries;
   }
-  
+
   std::vector<std::filesystem::directory_entry> get_subdirectories(const std::filesystem::path& path)
   {
     std::vector<std::filesystem::directory_entry> entries;
@@ -52,10 +52,10 @@ namespace fsw
 
     try
     {
-      for (const auto& entry : std::filesystem::directory_iterator(path)) 
+      for (const auto& entry : std::filesystem::directory_iterator(path))
         if (entry.is_directory()) entries.emplace_back(entry);
-    } 
-    catch (const std::filesystem::filesystem_error& e) 
+    }
+    catch (const std::filesystem::filesystem_error& e)
     {
       FSW_ELOGF(_("Error accessing directory: %s"), e.what());
     }
@@ -79,10 +79,15 @@ namespace fsw
 
   bool lstat_path(const std::string& path, struct stat& fd_stat)
   {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+    fsw_logf_perror(_("Cannot lstat %s (not implemented on Windows)"), path.c_str());
+    return false;
+#else
     if (lstat(path.c_str(), &fd_stat) == 0)
       return true;
 
     fsw_logf_perror(_("Cannot lstat %s"), path.c_str());
     return false;
+#endif
   }
 }

--- a/libfswatch/src/libfswatch/c++/windows/win_strings.cpp
+++ b/libfswatch/src/libfswatch/c++/windows/win_strings.cpp
@@ -15,6 +15,7 @@
  */
 #include "win_strings.hpp"
 #include <windows.h>
+#include <vector>
 
 namespace fsw
 {
@@ -22,18 +23,18 @@ namespace fsw
   {
     using namespace std;
 
-    string wstring_to_string(wchar_t * s)
+    string wstring_to_string(wchar_t *s)
     {
       int buf_size = WideCharToMultiByte(CP_UTF8, 0, s, -1, NULL, 0, NULL, NULL);
-      char buf[buf_size];
-      WideCharToMultiByte(CP_UTF8, 0, s, -1, buf, buf_size, NULL, NULL);
+      std::vector<char> buf(buf_size);
+      WideCharToMultiByte(CP_UTF8, 0, s, -1, buf.data(), buf_size, NULL, NULL);
 
-      return string(buf);
+      return std::string(buf.data());
     }
 
-    string wstring_to_string(const wstring & s)
+    string wstring_to_string(const wstring &s)
     {
-      return wstring_to_string((wchar_t *)s.c_str());
+      return wstring_to_string((wchar_t *) s.c_str());
     }
   }
 }

--- a/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/libfswatch/src/libfswatch/c/libfswatch.h
@@ -90,7 +90,7 @@ extern "C"
    * returns FSW_OK, otherwise the initialization routine failed and the library
    * should not be usable.
    */
-  FSW_STATUS fsw_init_library();
+  FSW_STATUS fsw_init_library(void);
 
   /**
    * This function creates a new monitor session using the specified monitor
@@ -195,12 +195,12 @@ extern "C"
   /**
    * Gets the last error code.
    */
-  FSW_STATUS fsw_last_error();
+  FSW_STATUS fsw_last_error(void);
 
   /**
    * Check whether the verbose mode is active.
    */
-  bool fsw_is_verbose();
+  bool fsw_is_verbose(void);
 
   /**
    * Set the verbose mode.


### PR DESCRIPTION
As I proposed in https://github.com/emcrisostomo/fswatch/issues/214#issuecomment-2639274929, and mainly based on the great work by [brechtsanders](https://github.com/brechtsanders) in #214, these are the minimal changes needed to compile 'libfswatch' using cmake, which is a step in building the R binding.

There are 2 further commits to remove warnings/errors which surface in the mandatory toolchains we have for building R packages at our central repository. These should be straightforward.

Apologies for some of the whitespace-only changes - it's just my editor...

If you're fine merging these then I'll make a cut of my R package that uses the updated library version, and you'll know that it's tested on my side at least. Conversely, for those using Windows with Cygwin, this shouldn't result in any change for them.