### PR TITLE
inotify monitor doesn't detect fast file creation recursively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ include(FindIntl)
 include(CheckIncludeFileCXX)
 include(CheckStructHasMember)
 include(CheckCXXSymbolExists)
+include(CTest)
 
 # check for gettext and libintl
 check_include_file_cxx(getopt.h HAVE_GETOPT_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2025 Enrico M. Crisostomo
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -64,6 +64,7 @@ namespace fsw
     std::unordered_set<int> descriptors_to_remove;
     std::unordered_set<int> watches_to_remove;
     std::vector<std::string> paths_to_rescan;
+    std::vector<std::string> paths_to_fire_create;
     time_t curr_time;
   };
 
@@ -212,11 +213,6 @@ namespace fsw
       impl->events.emplace_back(impl->wd_to_path[event->wd], impl->curr_time, flags, event->cookie);
     }
 
-    // If a new directory has been created, it should be rescanned if the
-    if ((event->mask & IN_ISDIR) && (event->mask & IN_CREATE))
-    {
-      impl->paths_to_rescan.push_back(impl->wd_to_path[event->wd]);
-    }
   }
 
   void inotify_monitor::preprocess_node_event(const struct inotify_event *event)
@@ -241,6 +237,13 @@ namespace fsw
     {
       filename_stream << "/";
       filename_stream << event->name;
+    }
+
+    if ((event->mask & IN_ISDIR) && (event->mask & IN_CREATE))
+    {
+      const std::string created_dir_path = filename_stream.str();
+      impl->paths_to_rescan.push_back(created_dir_path);
+      impl->paths_to_fire_create.push_back(created_dir_path);
     }
 
     if (!flags.empty())
@@ -374,6 +377,34 @@ namespace fsw
     impl->paths_to_rescan.clear();
   }
 
+  void inotify_monitor::process_synthetic_events()
+  {
+    for (const std::string& path : impl->paths_to_fire_create)
+    {
+      FSW_ELOGF(_("Synthetic event: processing directory: %s\n"), path.c_str());
+
+      const auto entries = get_directory_entries(path);
+
+      for (const auto& entry : entries)
+      {
+        std::vector<fsw_event_flag> flags{fsw_event_flag::Created};
+
+        try
+        {
+          if (entry.is_directory()) flags.push_back(fsw_event_flag::IsDir);
+        }
+        catch (const std::filesystem::filesystem_error& e)
+        {
+          FSW_ELOGF(_("Filesystem error: %s"), e.what());
+        }
+
+        impl->events.emplace_back(entry.path().string(), impl->curr_time, flags);
+      }
+    }
+
+    impl->paths_to_fire_create.clear();
+  }
+
   void inotify_monitor::run()
   {
     char buffer[BUFFER_SIZE];
@@ -454,6 +485,15 @@ namespace fsw
 
         p += (sizeof(struct inotify_event)) + event->len;
       }
+
+      if (!impl->events.empty())
+      {
+        notify_events(impl->events);
+        impl->events.clear();
+      }
+
+      process_pending_events();
+      process_synthetic_events();
 
       if (!impl->events.empty())
       {

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
@@ -84,6 +84,7 @@ namespace fsw
     void scan(const std::filesystem::path& path, const bool accept_non_dirs = true);
     bool add_watch(const std::string& path);
     void process_pending_events();
+    void process_synthetic_events();
     void remove_watch(int fd);
 
     std::unique_ptr<fsw::inotify_monitor_impl> impl;

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,7 +17,7 @@
  * @file
  * @brief Solaris/Illumos monitor.
  *
- * @copyright Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.8.0

--- a/libfswatch/src/libfswatch/c++/path_utils.cpp
+++ b/libfswatch/src/libfswatch/c++/path_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/libfswatch/src/libfswatch/c++/path_utils.cpp
+++ b/libfswatch/src/libfswatch/c++/path_utils.cpp
@@ -28,11 +28,11 @@ namespace fsw
   std::vector<std::filesystem::directory_entry> get_directory_entries(const std::filesystem::path& path)
   {
     std::vector<std::filesystem::directory_entry> entries;
-    // Reserve capacity to optimize memory allocation
-    entries.reserve(std::distance(std::filesystem::directory_iterator(path), std::filesystem::directory_iterator{}));
 
     try
     {
+      entries.reserve(std::distance(std::filesystem::directory_iterator(path), std::filesystem::directory_iterator{}));
+
       for (const auto& entry : std::filesystem::directory_iterator(path))
         entries.emplace_back(entry);
     }

--- a/test/inotify_recursive_create.sh
+++ b/test/inotify_recursive_create.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 FSWATCH GIT" >&2
+  exit 2
+fi
+
+FSWATCH=$1
+GIT=$2
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-recursive.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+cd "${WORKDIR}"
+"${GIT}" init -q
+
+"${FSWATCH}" -m inotify_monitor -rx --event Created .git > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+echo one > 1.txt
+"${GIT}" add 1.txt
+
+found=
+attempt=0
+
+while [ "${attempt}" -lt 8 ]; do
+  if grep -Eq '/\.git/objects/[^/]+/[^/]+ Created$' "${WORKDIR}/out.log"; then
+    found=1
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "missing synthetic create event for git object file" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,80p' "${WORKDIR}/err.log" >&2
+  echo "--- git object files ---" >&2
+  find "${WORKDIR}/.git/objects" -type f -print >&2
+  exit 1
+fi

--- a/test/inotify_recursive_create.sh
+++ b/test/inotify_recursive_create.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+#
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -eu
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2022 Enrico M. Crisostomo
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -21,3 +21,19 @@ add_executable(fswatch_test ${SOURCE_FILES})
 target_include_directories(fswatch_test PRIVATE ../.. .)
 target_include_directories(fswatch_test PRIVATE ${PROJECT_BINARY_DIR})
 target_link_libraries(fswatch_test PUBLIC libfswatch)
+
+if (BUILD_TESTING)
+    find_program(SH_EXECUTABLE sh)
+    find_program(GIT_EXECUTABLE git)
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SH_EXECUTABLE AND GIT_EXECUTABLE)
+        add_test(NAME inotify_recursive_create
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/inotify_recursive_create.sh
+                        $<TARGET_FILE:fswatch>
+                        ${GIT_EXECUTABLE})
+        set_tests_properties(inotify_recursive_create PROPERTIES
+                LABELS "integration;inotify"
+                TIMEOUT 15)
+    endif ()
+endif ()


### PR DESCRIPTION
## Summary

Fixes recursive inotify missed events when files are created immediately inside a newly-created directory.

When inotify reports a new directory, fswatch now:

- records the actual created directory path
- rescans that directory so watches are installed
- emits synthetic `Created` events for entries already present in that directory

This covers the race described in #330, where workflows such as `git add` can create `.git/objects/<prefix>/` and immediately write an object file inside it before fswatch has installed a watch on the new directory.

The change also hardens `get_directory_entries()` so directory iterator construction is inside the existing `try` block. If a newly-created directory disappears before synthetic processing, the error is logged and the monitor keeps running.

## Testing

```sh
cmake -S . -B /tmp/fswatch-build-330 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++
cmake --build /tmp/fswatch-build-330 --target fswatch -j2
```

Manual #330 reproduction steps:

```sh
tmp=$(mktemp -d /tmp/fswatch-330-clean.XXXXXX)
cd "$tmp"
git init -q
/tmp/fswatch-build-330/fswatch/src/fswatch -m inotify_monitor -rx --event Created .git > "$tmp/out.log" 2> "$tmp/err.log" &
pid=$!
sleep 1
echo one > 1.txt
git add 1.txt
sleep 2
kill "$pid" 2>/dev/null || true
wait "$pid" 2>/dev/null || true
```

Observed output included the previously-missing object file event:

```text
/tmp/fswatch-330-clean.BoJhxS/.git/objects/56 Created
/tmp/fswatch-330-clean.BoJhxS/.git/objects/56/26abf0f72e58d7a153368ba57db4c673c0e171 Created
```