### PR TITLE
Improve release harness

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -64,7 +64,7 @@ jobs:
         ./configure
 
     - name: Build and Test
-      run: make distcheck
+      run: make -j distcheck
 
     - name: Check distribution tarball
       run: scripts/release/check.zsh --release --require-dist ${{ github.event.release.tag_name }}
@@ -80,7 +80,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build PDF documentation
-      run: make pdf    
+      run: make -j pdf
 
     - name: Upload Release PDF documentation
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -9,17 +9,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.release.tag_name }}
 
     - name: Check autotools status
       id: check_status
       uses: actions/github-script@v4
       with:
         script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const tagName = context.payload.release.tag_name;
+          const tagRef = await github.git.getRef({
+            owner,
+            repo,
+            ref: `tags/${tagName}`
+          });
+
+          let releaseCommit = tagRef.data.object.sha;
+          if (tagRef.data.object.type === 'tag') {
+            const tag = await github.git.getTag({
+              owner,
+              repo,
+              tag_sha: releaseCommit
+            });
+            releaseCommit = tag.data.object.sha;
+          }
+
           const status = await github.repos.getCombinedStatusForRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: context.payload.release.target_commitish
+            owner,
+            repo,
+            ref: releaseCommit
           });
           const autotoolsStatus = status.data.statuses.find(s => s.context === 'autotools');
           if (!autotoolsStatus || autotoolsStatus.state !== 'success') {
@@ -29,7 +50,10 @@ jobs:
     - name: Install dependencies on Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install -y autoconf automake autopoint g++ gettext git libtool make texinfo texlive
+        sudo apt-get install -y autoconf automake autopoint g++ gettext git libtool make texinfo texlive zsh
+
+    - name: Check release metadata
+      run: scripts/release/check.zsh --release ${{ github.event.release.tag_name }}
 
     - name: Run autogen
       run: ./autogen.sh
@@ -41,6 +65,9 @@ jobs:
 
     - name: Build and Test
       run: make distcheck
+
+    - name: Check distribution tarball
+      run: scripts/release/check.zsh --release --require-dist ${{ github.event.release.tag_name }}
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ fswatch/doc/fswatch.pdf
 
 # Distribution files
 *.tar.gz
+release-notes.md
 
 # GNU Build System
 autom4te.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(fswatch VERSION 1.19.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-develop")
+set(VERSION_MODIFIER "-rc1")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/INSTALL
+++ b/INSTALL
@@ -13,7 +13,10 @@ Basic Installation
 
 should configure, build, and install this package.  The first line,
 which bootstraps, is intended for developers; when building from
-distribution tarballs it does nothing and can be skipped.
+distribution tarballs it does nothing and can be skipped.  A package
+might name the bootstrapping script differently; if the name is
+‘autogen.sh’, for example, the first line should say ‘./autogen.sh’
+instead of ‘./bootstrap’.
 
    The following more-detailed instructions are generic; see the
 ‘README’ file for instructions specific to this package.  Some packages
@@ -25,23 +28,22 @@ found in the GNU Coding Standards.
    Many packages have scripts meant for developers instead of ordinary
 builders, as they may use developer tools that are less commonly
 installed, or they may access the network, which has privacy
-implications.  If the ‘bootstrap’ shell script exists, it attempts to
-build the ‘configure’ shell script and related files, possibly using
-developer tools or the network.  Because the output of ‘bootstrap’ is
-system-independent, it is normally run by a package developer so that
-its output can be put into the distribution tarball and ordinary
-builders and users need not run ‘bootstrap’.  Some packages have
-commands like ‘./autopull.sh’ and ‘./autogen.sh’ that you can run
-instead of ‘./bootstrap’, for more fine-grained control over
-bootstrapping.
+implications.  These scripts attempt to bootstrap by building the
+‘configure’ script and related files, possibly using developer tools or
+the network.  Because the output of bootstrapping is system-independent,
+it is normally run by a package developer so that its output can be put
+into the distribution tarball and ordinary builders and users need not
+bootstrap.  Some packages have commands like ‘./autopull.sh’ and
+‘./autogen.sh’ that you can run instead of ‘./bootstrap’, for more
+fine-grained control over bootstrapping.
 
-   The ‘configure’ shell script attempts to guess correct values for
-various system-dependent variables used during compilation.  It uses
-those values to create a ‘Makefile’ in each directory of the package.
-It may also create one or more ‘.h’ files containing system-dependent
-definitions.  Finally, it creates a shell script ‘config.status’ that
-you can run in the future to recreate the current configuration, and a
-file ‘config.log’ containing output useful for debugging ‘configure’.
+   The ‘configure’ script attempts to guess correct values for various
+system-dependent variables used during compilation.  It uses those
+values to create a ‘Makefile’ in each directory of the package.  It may
+also create one or more ‘.h’ files containing system-dependent
+definitions.  Finally, it creates a script ‘config.status’ that you can
+run in the future to recreate the current configuration, and a file
+‘config.log’ containing output useful for debugging ‘configure’.
 
    It can also use an optional file (typically called ‘config.cache’ and
 enabled with ‘--cache-file=config.cache’ or simply ‘-C’) that saves the
@@ -64,9 +66,10 @@ editing ‘configure’ directly.
   1. ‘cd’ to the directory containing the package’s source code.
 
   2. If this is a developer checkout and file ‘configure’ does not yet
-     exist, type ‘./bootstrap’ to create it.  You may need special
-     developer tools and network access to bootstrap, and the network
-     access may have privacy implications.
+     exist, run the bootstrapping script (typically ‘./bootstrap’ or
+     ‘./autogen.sh’) to bootstrap and create the file.  You may need
+     special developer tools and network access to bootstrap, and the
+     network access may have privacy implications.
 
   3. Type ‘./configure’ to configure the package for your system.  This
      might take a while.  While running, ‘configure’ prints messages
@@ -100,6 +103,18 @@ editing ‘configure’ directly.
 
   9. If the package follows the GNU Coding Standards, you can type ‘make
      uninstall’ to remove the installed files.
+
+Installation Prerequisites
+==========================
+
+   Installation requires a POSIX-like environment with a shell and at
+least the following standard utilities:
+
+     awk cat cp diff echo expr false ls mkdir mv printf pwd rm rmdir sed
+     sort test tr
+
+This package’s installation may need other standard utilities such as
+‘grep’, ‘make’, ‘sleep’ and ‘touch’, along with compilers like ‘gcc’.
 
 Compilers and Options
 =====================
@@ -356,7 +371,7 @@ more details.
 Copyright notice
 ================
 
-   Copyright © 1994–1996, 1999–2002, 2004–2017, 2020–2024 Free Software
+   Copyright © 1994–1996, 1999–2002, 2004–2017, 2020–2025 Free Software
 Foundation, Inc.
 
    Copying and distribution of this file, with or without modification,

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,14 @@ NEWS
 
 New in 1.19.0-rc1:
 
+  * PR 353, Issue 343: Fix a segmentation fault in the macOS FSEvents monitor
+    when file event metadata does not include an inode.
+
+  * PR 354, Issue 330: Fix recursive inotify monitoring so fast file creation
+    in newly-created directories is detected.
+
+  * PR 340: Enable libfswatch compilation under Windows MinGW.
+
   * Fix: spurious output 'inotify_rm_watch: Invalid argument'
 
   * Issue 335: v. 1.18.0: build error: 'kFSEventStreamCreateFlagFileEvents' was
@@ -10,7 +18,7 @@ New in 1.19.0-rc1:
 
   * Grammar fix in documentation.
 
-  * Fix: typo in man page. 
+  * Fix: typo in man page.
 
 New in 1.18.2:
 

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 NEWS
 ****
 
-New in 1.19.0-develop:
+New in 1.19.0-rc1:
 
   * Fix: spurious output 'inotify_rm_watch: Invalid argument'
 

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,6 +1,16 @@
 NEWS
 ****
 
+New in 1.19.0-rc1:
+
+  * PR 353, Issue 343: Fix a segmentation fault in the macOS FSEvents monitor
+    when file event metadata does not include an inode.
+
+  * PR 354, Issue 330: Fix recursive inotify monitoring so fast file creation
+    in newly-created directories is detected.
+
+  * PR 340: Enable libfswatch compilation under Windows MinGW.
+
 New in 1.18.0:
 
   * Documentation: add reference to Go bindings.

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2025 Enrico M. Crisostomo
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.19.0-develop])
+m4_define([FSWATCH_VERSION], [1.19.0-rc1])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2025 Enrico M. Crisostomo
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.19.0-develop])
+m4_define([LIBFSWATCH_VERSION], [1.19.0-rc1])
 m4_define([LIBFSWATCH_API_VERSION], [13:2:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-02-04 22:22+0100\n"
+"POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: English\n"
@@ -19,8 +19,8 @@ msgstr ""
 
 #: fswatch/src/fswatch.cpp:141
 msgid ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 msgstr ""
 
 #: fswatch/src/fswatch.cpp:142
@@ -315,9 +315,10 @@ msgid "Cannot allocate memory"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:176
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:398
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -356,79 +357,84 @@ msgstr ""
 msgid "Unknown flag: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:139
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
 msgid "Event stream could not be created."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:150
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
 msgid "Scheduling stream with run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
 msgid "Starting event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
 msgid "Starting run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:177
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
 msgid "Stopping event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
 msgid "Invalidating event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:183
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
 msgid "Releasing event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:198
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
 msgid "run loop is null"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
 msgid "Stopping run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:233
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:314
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
 msgid "Creating FSEvent stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:83
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
 msgid "Cannot initialize inotify."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:93
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
 msgid "Removing: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:122
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:123
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:253
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:256
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:345
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:348
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:432
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:384
+#, c-format
+msgid "Synthetic event: processing directory: %s\n"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:463
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:438
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:444
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 
@@ -506,12 +512,17 @@ msgstr ""
 msgid "Cannot stat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/path_utils.cpp:85
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:83
+#, c-format
+msgid "Cannot lstat %s (not implemented on Windows)"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:89
 #, c-format
 msgid "Cannot lstat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
 msgid "Done scanning.\n"
 msgstr ""
 
@@ -548,8 +559,8 @@ msgstr ""
 msgid "Closing handle: %d.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:30
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:42
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:36
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:56
 msgid "cygwin_create_path could not allocate memory to convert the path."
 msgstr ""
 

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -1,7 +1,7 @@
 # English translations for fswatch package.
-# Copyright (C) 2025 Enrico M. Crisostomo
+# Copyright (C) 2026 Enrico M. Crisostomo
 # This file is distributed under the same license as the fswatch package.
-# Automatically generated, 2025.
+# Automatically generated, 2026.
 #
 # All this catalog "translates" are quotation characters.
 # The msgids must be ASCII and therefore cannot contain real quotation
@@ -30,10 +30,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.18.3\n"
+"Project-Id-Version: fswatch 1.19.0-rc1\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-02-04 22:22+0100\n"
-"PO-Revision-Date: 2025-02-04 22:22+0100\n"
+"POT-Creation-Date: 2026-04-11 22:37+0200\n"
+"PO-Revision-Date: 2026-04-11 22:37+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@boldquot\n"
@@ -44,11 +44,11 @@ msgstr ""
 
 #: fswatch/src/fswatch.cpp:141
 msgid ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 msgstr ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 
 #: fswatch/src/fswatch.cpp:142
 msgid "This is free software: you are free to change and redistribute it.\n"
@@ -348,9 +348,10 @@ msgid "Cannot allocate memory"
 msgstr "Cannot allocate memory"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:176
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:398
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
@@ -389,79 +390,84 @@ msgstr "Unknown filter type: "
 msgid "Unknown flag: "
 msgstr "Unknown flag: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:139
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
 msgid "Event stream could not be created."
 msgstr "Event stream could not be created."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:150
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
 msgid "Scheduling stream with run loop...\n"
 msgstr "Scheduling stream with run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
 msgid "Starting event stream...\n"
 msgstr "Starting event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
 msgid "Starting run loop...\n"
 msgstr "Starting run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:177
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
 msgid "Stopping event stream...\n"
 msgstr "Stopping event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
 msgid "Invalidating event stream...\n"
 msgstr "Invalidating event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:183
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
 msgid "Releasing event stream...\n"
 msgstr "Releasing event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:198
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
 msgid "run loop is null"
 msgstr "run loop is null"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
 msgid "Stopping run loop...\n"
 msgstr "Stopping run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:233
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "The callback info cannot be cast to fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:314
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
 msgid "Creating FSEvent stream...\n"
 msgstr "Creating FSEvent stream...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:83
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
 msgid "Cannot initialize inotify."
 msgstr "Cannot initialize inotify."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:93
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
 msgid "Removing: "
 msgstr "Removing: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:122
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:123
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:253
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:256
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:345
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:348
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:432
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:384
+#, c-format
+msgid "Synthetic event: processing directory: %s\n"
+msgstr "Synthetic event: processing directory: %s\n"
+
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:463
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:438
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:444
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 
@@ -539,12 +545,17 @@ msgstr "Error accessing directory: %s"
 msgid "Cannot stat %s"
 msgstr "Cannot stat %s"
 
-#: libfswatch/src/libfswatch/c++/path_utils.cpp:85
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:83
+#, c-format
+msgid "Cannot lstat %s (not implemented on Windows)"
+msgstr "Cannot lstat %s (not implemented on Windows)"
+
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:89
 #, c-format
 msgid "Cannot lstat %s"
 msgstr "Cannot lstat %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
 msgid "Done scanning.\n"
 msgstr "Done scanning.\n"
 
@@ -581,8 +592,8 @@ msgstr "File name unexpectedly empty."
 msgid "Closing handle: %d.\n"
 msgstr "Closing handle: %d.\n"
 
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:30
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:42
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:36
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:56
 msgid "cygwin_create_path could not allocate memory to convert the path."
 msgstr "cygwin_create_path could not allocate memory to convert the path."
 

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -1,7 +1,7 @@
 # English translations for fswatch package.
-# Copyright (C) 2025 Enrico M. Crisostomo
+# Copyright (C) 2026 Enrico M. Crisostomo
 # This file is distributed under the same license as the fswatch package.
-# Automatically generated, 2025.
+# Automatically generated, 2026.
 #
 # All this catalog "translates" are quotation characters.
 # The msgids must be ASCII and therefore cannot contain real quotation
@@ -27,10 +27,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.18.3\n"
+"Project-Id-Version: fswatch 1.19.0-rc1\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-02-04 22:22+0100\n"
-"PO-Revision-Date: 2025-02-04 22:22+0100\n"
+"POT-Creation-Date: 2026-04-11 22:37+0200\n"
+"PO-Revision-Date: 2026-04-11 22:37+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@quot\n"
@@ -41,11 +41,11 @@ msgstr ""
 
 #: fswatch/src/fswatch.cpp:141
 msgid ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 msgstr ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 
 #: fswatch/src/fswatch.cpp:142
 msgid "This is free software: you are free to change and redistribute it.\n"
@@ -345,9 +345,10 @@ msgid "Cannot allocate memory"
 msgstr "Cannot allocate memory"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:176
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:398
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
@@ -386,79 +387,84 @@ msgstr "Unknown filter type: "
 msgid "Unknown flag: "
 msgstr "Unknown flag: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:139
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
 msgid "Event stream could not be created."
 msgstr "Event stream could not be created."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:150
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
 msgid "Scheduling stream with run loop...\n"
 msgstr "Scheduling stream with run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
 msgid "Starting event stream...\n"
 msgstr "Starting event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
 msgid "Starting run loop...\n"
 msgstr "Starting run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:177
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
 msgid "Stopping event stream...\n"
 msgstr "Stopping event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
 msgid "Invalidating event stream...\n"
 msgstr "Invalidating event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:183
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
 msgid "Releasing event stream...\n"
 msgstr "Releasing event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:198
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
 msgid "run loop is null"
 msgstr "run loop is null"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
 msgid "Stopping run loop...\n"
 msgstr "Stopping run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:233
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "The callback info cannot be cast to fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:314
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
 msgid "Creating FSEvent stream...\n"
 msgstr "Creating FSEvent stream...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:83
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
 msgid "Cannot initialize inotify."
 msgstr "Cannot initialize inotify."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:93
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
 msgid "Removing: "
 msgstr "Removing: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:122
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:123
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:253
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:256
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:345
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:348
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:432
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:384
+#, c-format
+msgid "Synthetic event: processing directory: %s\n"
+msgstr "Synthetic event: processing directory: %s\n"
+
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:463
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:438
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:444
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 
@@ -536,12 +542,17 @@ msgstr "Error accessing directory: %s"
 msgid "Cannot stat %s"
 msgstr "Cannot stat %s"
 
-#: libfswatch/src/libfswatch/c++/path_utils.cpp:85
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:83
+#, c-format
+msgid "Cannot lstat %s (not implemented on Windows)"
+msgstr "Cannot lstat %s (not implemented on Windows)"
+
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:89
 #, c-format
 msgid "Cannot lstat %s"
 msgstr "Cannot lstat %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
 msgid "Done scanning.\n"
 msgstr "Done scanning.\n"
 
@@ -578,8 +589,8 @@ msgstr "File name unexpectedly empty."
 msgid "Closing handle: %d.\n"
 msgstr "Closing handle: %d.\n"
 
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:30
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:42
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:36
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:56
 msgid "cygwin_create_path could not allocate memory to convert the path."
 msgstr "cygwin_create_path could not allocate memory to convert the path."
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-02-04 22:22+0100\n"
+"POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -19,11 +19,11 @@ msgstr ""
 
 #: fswatch/src/fswatch.cpp:141
 msgid ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 msgstr ""
-"Licencia GPLv3+: GNU GPL versión 3 o sucesiva <http://gnu.org/licenses/gpl."
-"html>.\n"
+"Licencia GPLv3+: GNU GPL versión 3 o sucesiva <http://gnu.org/licenses/"
+"gpl.html>.\n"
 
 #: fswatch/src/fswatch.cpp:142
 msgid "This is free software: you are free to change and redistribute it.\n"
@@ -326,9 +326,10 @@ msgid "Cannot allocate memory"
 msgstr "No se puede reservar memoria"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:176
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:398
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -367,83 +368,88 @@ msgstr "Tipo filtro desconocido: "
 msgid "Unknown flag: "
 msgstr "Flag desconocida: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:139
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
 msgid "Event stream could not be created."
 msgstr "El flujo de eventos no se puede crear."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:150
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
 msgid "Scheduling stream with run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
 msgid "Starting event stream...\n"
 msgstr "Arrancando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
 #, fuzzy
 #| msgid "Starting event stream...\n"
 msgid "Starting run loop...\n"
 msgstr "Arrancando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:177
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
 msgid "Stopping event stream...\n"
 msgstr "Parando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
 msgid "Invalidating event stream...\n"
 msgstr "Invalidando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:183
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
 msgid "Releasing event stream...\n"
 msgstr "Liberando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:198
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
 msgid "run loop is null"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
 #, fuzzy
 #| msgid "Stopping event stream...\n"
 msgid "Stopping run loop...\n"
 msgstr "Parando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:233
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "El context de callback no puede convertirse a fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:314
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
 msgid "Creating FSEvent stream...\n"
 msgstr "Creando el flujo FSEvent...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:83
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
 msgid "Cannot initialize inotify."
 msgstr "inotify no puede ser inicializado."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:93
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
 msgid "Removing: "
 msgstr "Eliminando: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:122
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:123
 msgid "Added: "
 msgstr "Añadiendo: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:253
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:256
 msgid "Generic event: "
 msgstr "Evento genérico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:345
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:348
 msgid "Removed: "
 msgstr "Eliminado: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:432
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:384
+#, c-format
+msgid "Synthetic event: processing directory: %s\n"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:463
 msgid "Number of records: "
 msgstr "Numero de registros: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:438
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sobre el descriptor inotify leyó 0 registros."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:444
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sobre le descriptor inotify devolvió -1."
 
@@ -521,12 +527,17 @@ msgstr ""
 msgid "Cannot stat %s"
 msgstr "No se puede hacer stat() de %s"
 
-#: libfswatch/src/libfswatch/c++/path_utils.cpp:85
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:83
+#, c-format
+msgid "Cannot lstat %s (not implemented on Windows)"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:89
 #, c-format
 msgid "Cannot lstat %s"
 msgstr "No se puede hacer lstat() de %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
 msgid "Done scanning.\n"
 msgstr "Rastreo terminado.\n"
 
@@ -563,8 +574,8 @@ msgstr "Nombre de fichero inesperadamente vacío."
 msgid "Closing handle: %d.\n"
 msgstr "Cerrando handle: %d.\n"
 
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:30
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:42
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:36
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:56
 msgid "cygwin_create_path could not allocate memory to convert the path."
 msgstr "cygwin_create_path no pudo alocar memoria para convertir la ruta."
 

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.18.3\n"
+"Project-Id-Version: fswatch 1.19.0-rc1\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-02-04 22:22+0100\n"
+"POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,8 +19,8 @@ msgstr ""
 
 #: fswatch/src/fswatch.cpp:141
 msgid ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 msgstr ""
 
 #: fswatch/src/fswatch.cpp:142
@@ -315,9 +315,10 @@ msgid "Cannot allocate memory"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:176
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:398
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -356,79 +357,84 @@ msgstr ""
 msgid "Unknown flag: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:139
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
 msgid "Event stream could not be created."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:150
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
 msgid "Scheduling stream with run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
 msgid "Starting event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
 msgid "Starting run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:177
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
 msgid "Stopping event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
 msgid "Invalidating event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:183
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
 msgid "Releasing event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:198
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
 msgid "run loop is null"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
 msgid "Stopping run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:233
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:314
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
 msgid "Creating FSEvent stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:83
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
 msgid "Cannot initialize inotify."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:93
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
 msgid "Removing: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:122
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:123
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:253
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:256
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:345
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:348
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:432
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:384
+#, c-format
+msgid "Synthetic event: processing directory: %s\n"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:463
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:438
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:444
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 
@@ -506,12 +512,17 @@ msgstr ""
 msgid "Cannot stat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/path_utils.cpp:85
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:83
+#, c-format
+msgid "Cannot lstat %s (not implemented on Windows)"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:89
 #, c-format
 msgid "Cannot lstat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
 msgid "Done scanning.\n"
 msgstr ""
 
@@ -548,8 +559,8 @@ msgstr ""
 msgid "Closing handle: %d.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:30
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:42
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:36
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:56
 msgid "cygwin_create_path could not allocate memory to convert the path."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2025-02-04 22:22+0100\n"
+"POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: 2018-05-02 17:29+0200\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -19,11 +19,11 @@ msgstr ""
 
 #: fswatch/src/fswatch.cpp:141
 msgid ""
-"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl."
-"html>.\n"
+"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
+"gpl.html>.\n"
 msgstr ""
-"Licenza GLPv3+: GNU GPL versione 3 o successive <http://gnu.org/licenses/gpl."
-"html>.\n"
+"Licenza GLPv3+: GNU GPL versione 3 o successive <http://gnu.org/licenses/"
+"gpl.html>.\n"
 
 #: fswatch/src/fswatch.cpp:142
 msgid "This is free software: you are free to change and redistribute it.\n"
@@ -326,9 +326,10 @@ msgid "Cannot allocate memory"
 msgstr "Non si può allocare memoria"
 
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:175
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:176
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:398
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
@@ -367,83 +368,88 @@ msgstr "Tipo filtro sconosciuto: "
 msgid "Unknown flag: "
 msgstr "Flag sconosciuto: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:139
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
 msgid "Event stream could not be created."
 msgstr "Il flusso di eventi non può essere creato."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:150
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
 msgid "Scheduling stream with run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:156
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
 msgid "Starting event stream...\n"
 msgstr "Facendo partire il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
 #, fuzzy
 #| msgid "Starting event stream...\n"
 msgid "Starting run loop...\n"
 msgstr "Facendo partire il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:177
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
 msgid "Stopping event stream...\n"
 msgstr "Fermando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:180
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
 msgid "Invalidating event stream...\n"
 msgstr "Invalidando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:183
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
 msgid "Releasing event stream...\n"
 msgstr "Liberando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:198
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
 msgid "run loop is null"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
 #, fuzzy
 #| msgid "Stopping event stream...\n"
 msgid "Stopping run loop...\n"
 msgstr "Fermando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:233
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "Il contesto del callback non può essere convertita a fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:314
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
 msgid "Creating FSEvent stream...\n"
 msgstr "Creando il flusso FSEvent...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:83
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
 msgid "Cannot initialize inotify."
 msgstr "Non si può inizializzare inotify."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:93
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
 msgid "Removing: "
 msgstr "Eliminando: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:122
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:123
 msgid "Added: "
 msgstr "Aggiunto: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:253
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:256
 msgid "Generic event: "
 msgstr "Evento generico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:345
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:348
 msgid "Removed: "
 msgstr "Eliminato: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:432
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:384
+#, c-format
+msgid "Synthetic event: processing directory: %s\n"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:463
 msgid "Number of records: "
 msgstr "Numero di registri: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:438
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sul descrittore inotify ha trovato 0 registri."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:444
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sul descrittore inotify ha ritornato -1."
 
@@ -521,12 +527,17 @@ msgstr ""
 msgid "Cannot stat %s"
 msgstr "Non posso eseguire stat() di %s"
 
-#: libfswatch/src/libfswatch/c++/path_utils.cpp:85
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:83
+#, c-format
+msgid "Cannot lstat %s (not implemented on Windows)"
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/path_utils.cpp:89
 #, c-format
 msgid "Cannot lstat %s"
 msgstr "Non posso eseguire lstat() di %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:224
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
 msgid "Done scanning.\n"
 msgstr "Scansione terminata.\n"
 
@@ -563,8 +574,8 @@ msgstr "Nome file inaspettatamente vuoto."
 msgid "Closing handle: %d.\n"
 msgstr "Chiudendo handle: %d.\n"
 
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:30
-#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:42
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:36
+#: libfswatch/src/libfswatch/c++/windows/win_paths.cpp:56
 msgid "cygwin_create_path could not allocate memory to convert the path."
 msgstr ""
 "cygwin_create_path non ha potuto allocare memoria per convertire il path."

--- a/scripts/release/check.zsh
+++ b/scripts/release/check.zsh
@@ -1,0 +1,238 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+PROGNAME=${0:t}
+PROGDIR=${0:A:h}
+
+. "${PROGDIR}/lib.zsh"
+
+usage()
+{
+  print -- "Usage: ${PROGNAME} [options] VERSION"
+  print
+  print -- "Validate fswatch release metadata without modifying the repository."
+  print
+  print -- "Options:"
+  print -- "  --release                  Require VERSION to be a releasable version, not -develop."
+  print -- "  --require-clean            Require no tracked working-tree changes."
+  print -- "  --require-dist             Require fswatch-VERSION.tar.gz to exist."
+  print -- "  --require-annotated-tag    Require VERSION to exist as an annotated local tag."
+  print -- "  --require-libfswatch-news  Require NEWS.libfswatch top section to match VERSION."
+  print -- "  --notes FILE               Validate a GitHub release notes file."
+  print -- "  -h, --help                 Print this message."
+}
+
+typeset -i release_mode=0
+typeset -i require_clean=0
+typeset -i require_dist=0
+typeset -i require_annotated_tag=0
+typeset -i require_libfswatch_news=0
+notes_file=
+
+while (( $# > 0 ))
+do
+  case "$1" in
+    --release)
+      release_mode=1
+      shift
+      ;;
+    --require-clean)
+      require_clean=1
+      shift
+      ;;
+    --require-dist)
+      require_dist=1
+      shift
+      ;;
+    --require-annotated-tag)
+      require_annotated_tag=1
+      shift
+      ;;
+    --require-libfswatch-news)
+      require_libfswatch_news=1
+      shift
+      ;;
+    --notes)
+      (( $# >= 2 )) || release_die "--notes requires a file"
+      notes_file=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      release_die "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+(( $# == 1 )) || {
+  usage
+  exit 1
+}
+
+release_parse_version "$1"
+
+repo_root=$(release_repo_root)
+cd "${repo_root}"
+
+typeset -i failures=0
+
+fail()
+{
+  print -u2 -- "FAIL: $*"
+  failures+=1
+}
+
+pass()
+{
+  print -- "ok: $*"
+}
+
+check_equal()
+{
+  local label=$1
+  local expected=$2
+  local actual=$3
+
+  if [[ "${actual}" == "${expected}" ]]
+  then
+    pass "${label} is ${expected}"
+  else
+    fail "${label}: expected '${expected}', found '${actual}'"
+  fi
+}
+
+if (( release_mode && RELEASE_IS_DEVELOP ))
+then
+  fail "--release does not allow -develop versions"
+fi
+
+if (( require_clean ))
+then
+  tracked_status=$(git status --short --untracked-files=no)
+  if [[ -z "${tracked_status}" ]]
+  then
+    pass "tracked working tree is clean"
+  else
+    fail "tracked working tree has changes"
+    print -u2 -- "${tracked_status}"
+  fi
+fi
+
+fswatch_version=$(release_m4_define m4/fswatch_version.m4 FSWATCH_VERSION)
+libfswatch_version=$(release_m4_define m4/libfswatch_version.m4 LIBFSWATCH_VERSION)
+libfswatch_api_version=$(release_m4_define m4/libfswatch_version.m4 LIBFSWATCH_API_VERSION)
+cmake_project_version=$(release_cmake_project_version)
+cmake_version_modifier=$(release_cmake_version_modifier)
+news_version=$(release_news_top_version NEWS)
+libfswatch_news_version=$(release_news_top_version NEWS.libfswatch)
+
+check_equal "FSWATCH_VERSION" "${RELEASE_VERSION}" "${fswatch_version}"
+check_equal "LIBFSWATCH_VERSION" "${RELEASE_VERSION}" "${libfswatch_version}"
+check_equal "CMake project version" "${RELEASE_BASE_VERSION}" "${cmake_project_version}"
+check_equal "CMake VERSION_MODIFIER" "${RELEASE_VERSION_MODIFIER}" "${cmake_version_modifier}"
+check_equal "NEWS top version" "${RELEASE_VERSION}" "${news_version}"
+
+if [[ "${libfswatch_news_version}" == "${RELEASE_VERSION}" ]]
+then
+  pass "NEWS.libfswatch top version is ${RELEASE_VERSION}"
+elif (( require_libfswatch_news ))
+then
+  fail "NEWS.libfswatch: expected top version '${RELEASE_VERSION}', found '${libfswatch_news_version}'"
+else
+  release_warn "NEWS.libfswatch top version is '${libfswatch_news_version}', not '${RELEASE_VERSION}'"
+fi
+
+if [[ "${libfswatch_api_version}" == <->:<->:<-> ]]
+then
+  pass "LIBFSWATCH_API_VERSION is ${libfswatch_api_version}"
+else
+  fail "LIBFSWATCH_API_VERSION is not current:revision:age: '${libfswatch_api_version}'"
+fi
+
+if (( require_dist ))
+then
+  dist_file="fswatch-${RELEASE_VERSION}.tar.gz"
+  if [[ -f "${dist_file}" ]]
+  then
+    pass "distribution tarball exists: ${dist_file}"
+  else
+    fail "distribution tarball is missing: ${dist_file}"
+  fi
+fi
+
+if (( require_annotated_tag ))
+then
+  tag_type=$(release_tag_type "${RELEASE_VERSION}")
+  if [[ "${tag_type}" == "tag" ]]
+  then
+    pass "local tag ${RELEASE_VERSION} is annotated"
+  elif [[ -z "${tag_type}" ]]
+  then
+    fail "local tag ${RELEASE_VERSION} does not exist"
+  else
+    fail "local tag ${RELEASE_VERSION} is '${tag_type}', not an annotated tag"
+  fi
+fi
+
+if [[ -n "${notes_file}" ]]
+then
+  if [[ ! -f "${notes_file}" ]]
+  then
+    fail "release notes file does not exist: ${notes_file}"
+  else
+    expected_title="# What's New in fswatch v. ${RELEASE_VERSION}:"
+    if grep -Fqx "${expected_title}" "${notes_file}"
+    then
+      pass "release notes title matches ${RELEASE_VERSION}"
+    else
+      fail "release notes title is missing: ${expected_title}"
+    fi
+
+    expected_intro="\`fswatch\` v. ${RELEASE_VERSION} introduces the following features and bug fixes:"
+    if grep -Fqx "${expected_intro}" "${notes_file}"
+    then
+      pass "release notes fswatch intro matches ${RELEASE_VERSION}"
+    else
+      fail "release notes fswatch intro is missing"
+    fi
+  fi
+fi
+
+if (( failures > 0 ))
+then
+  print -u2 -- "${failures} release check(s) failed."
+  exit 1
+fi
+
+print -- "All release checks passed for ${RELEASE_VERSION}."

--- a/scripts/release/lib.zsh
+++ b/scripts/release/lib.zsh
@@ -1,0 +1,116 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+RELEASE_REPO=${RELEASE_REPO:-emcrisostomo/fswatch}
+
+release_die()
+{
+  print -u2 -- "error: $*"
+  exit 1
+}
+
+release_warn()
+{
+  print -u2 -- "warning: $*"
+}
+
+release_info()
+{
+  print -- "$*"
+}
+
+release_repo_root()
+{
+  git rev-parse --show-toplevel 2> /dev/null ||
+    release_die "not inside a git repository"
+}
+
+release_parse_version()
+{
+  (( $# == 1 )) || release_die "release_parse_version expects one argument"
+
+  RELEASE_VERSION=$1
+  if [[ "${RELEASE_VERSION}" =~ '^([0-9]+[.][0-9]+[.][0-9]+)(-rc[0-9]+|-develop)?$' ]]
+  then
+    RELEASE_BASE_VERSION=${match[1]}
+    RELEASE_VERSION_MODIFIER=${match[2]:-}
+  else
+    release_die "invalid version '${RELEASE_VERSION}'; expected X.Y.Z, X.Y.Z-rcN, or X.Y.Z-develop"
+  fi
+
+  RELEASE_IS_DEVELOP=0
+  RELEASE_IS_PRERELEASE=0
+
+  if [[ "${RELEASE_VERSION_MODIFIER}" == "-develop" ]]
+  then
+    RELEASE_IS_DEVELOP=1
+  elif [[ "${RELEASE_VERSION_MODIFIER}" == -rc<-> ]]
+  then
+    RELEASE_IS_PRERELEASE=1
+  elif [[ -n "${RELEASE_VERSION_MODIFIER}" ]]
+  then
+    release_die "unsupported version modifier '${RELEASE_VERSION_MODIFIER}'"
+  fi
+}
+
+release_m4_define()
+{
+  (( $# == 2 )) || release_die "release_m4_define expects file and macro name"
+  local file=$1
+  local macro=$2
+
+  sed -n "s/^m4_define(\\[${macro}\\], \\[\\([^]]*\\)\\])$/\\1/p" "${file}" |
+    tail -n 1
+}
+
+release_cmake_project_version()
+{
+  sed -n 's/^project(fswatch VERSION *\([^ ]*\) .*/\1/p' CMakeLists.txt |
+    tail -n 1
+}
+
+release_cmake_version_modifier()
+{
+  sed -n 's/^set(VERSION_MODIFIER *"\([^"]*\)")$/\1/p' CMakeLists.txt |
+    tail -n 1
+}
+
+release_news_top_version()
+{
+  (( $# == 1 )) || release_die "release_news_top_version expects one file"
+  sed -n 's/^New in \(.*\):$/\1/p' "$1" |
+    head -n 1
+}
+
+release_tag_exists()
+{
+  (( $# == 1 )) || release_die "release_tag_exists expects one tag"
+  git rev-parse -q --verify "refs/tags/$1" > /dev/null
+}
+
+release_tag_type()
+{
+  (( $# == 1 )) || release_die "release_tag_type expects one tag"
+  git cat-file -t "$1" 2> /dev/null || true
+}

--- a/scripts/release/notes.zsh
+++ b/scripts/release/notes.zsh
@@ -1,0 +1,142 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+PROGNAME=${0:t}
+PROGDIR=${0:A:h}
+
+. "${PROGDIR}/lib.zsh"
+
+usage()
+{
+  print -- "Usage: ${PROGNAME} [options] VERSION"
+  print
+  print -- "Generate a GitHub release-note draft from NEWS files."
+  print
+  print -- "Options:"
+  print -- "  -o, --output FILE           Write notes to FILE instead of stdout."
+  print -- "  --require-libfswatch-news  Fail if NEWS.libfswatch has no VERSION section."
+  print -- "  -h, --help                 Print this message."
+}
+
+output_file=
+typeset -i require_libfswatch_news=0
+
+while (( $# > 0 ))
+do
+  case "$1" in
+    -o|--output)
+      (( $# >= 2 )) || release_die "$1 requires a file"
+      output_file=$2
+      shift 2
+      ;;
+    --require-libfswatch-news)
+      require_libfswatch_news=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      release_die "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+(( $# == 1 )) || {
+  usage
+  exit 1
+}
+
+release_parse_version "$1"
+
+repo_root=$(release_repo_root)
+cd "${repo_root}"
+
+extract_section()
+{
+  local file=$1
+  local version=$2
+
+  awk -v version="${version}" '
+    BEGIN { found = 0; n = 0 }
+    $0 == "New in " version ":" { found = 1; next }
+    found && /^New in / { exit }
+    found { lines[++n] = $0 }
+    END {
+      if (!found) exit 2
+      start = 1
+      while (start <= n && lines[start] == "") start++
+      end = n
+      while (end >= start && lines[end] == "") end--
+      for (i = start; i <= end; i++) print lines[i]
+    }
+  ' "${file}"
+}
+
+fswatch_section=$(extract_section NEWS "${RELEASE_VERSION}") ||
+  release_die "NEWS has no section for ${RELEASE_VERSION}"
+
+libfswatch_section=
+if libfswatch_section=$(extract_section NEWS.libfswatch "${RELEASE_VERSION}" 2> /dev/null)
+then
+  :
+elif (( require_libfswatch_news ))
+then
+  release_die "NEWS.libfswatch has no section for ${RELEASE_VERSION}"
+else
+  libfswatch_section=
+fi
+
+render_notes()
+{
+  print -- "# What's New in fswatch v. ${RELEASE_VERSION}:"
+  print
+  print -- "\`fswatch\` v. ${RELEASE_VERSION} introduces the following features and bug fixes:"
+  print
+  print -- "${fswatch_section}"
+
+  if [[ -n "${libfswatch_section}" ]]
+  then
+    print
+    print -- "\`libfswatch\` v. ${RELEASE_VERSION} introduces the following features and bug fixes:"
+    print
+    print -- "${libfswatch_section}"
+  fi
+}
+
+if [[ -n "${output_file}" ]]
+then
+  render_notes > "${output_file}"
+  print -- "Wrote release-note draft: ${output_file}"
+else
+  render_notes
+fi

--- a/scripts/release/post-release.zsh
+++ b/scripts/release/post-release.zsh
@@ -1,0 +1,110 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+PROGNAME=${0:t}
+PROGDIR=${0:A:h}
+
+. "${PROGDIR}/lib.zsh"
+
+usage()
+{
+  print -- "Usage: ${PROGNAME} [--apply] NEXT_VERSION"
+  print
+  print -- "Prepare version files for the next development cycle."
+  print -- "NEXT_VERSION must be numeric X.Y.Z; this script appends -develop."
+}
+
+typeset -i apply=0
+
+while (( $# > 0 ))
+do
+  case "$1" in
+    --apply)
+      apply=1
+      shift
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      release_die "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+(( $# == 1 )) || {
+  usage
+  exit 1
+}
+
+next_version=$1
+release_parse_version "${next_version}"
+
+[[ -z "${RELEASE_VERSION_MODIFIER}" ]] ||
+  release_die "NEXT_VERSION must be numeric X.Y.Z; got ${next_version}"
+
+develop_version="${next_version}-develop"
+
+if (( apply ))
+then
+  "${PROGDIR}/prepare.zsh" --apply "${develop_version}"
+  current_news_version=$(release_news_top_version NEWS)
+  if [[ "${current_news_version}" != "${develop_version}" ]]
+  then
+    tmp_file=NEWS.tmp.$$
+    awk -v version="${develop_version}" '
+      NR == 1 { print; next }
+      NR == 2 {
+        print
+        print ""
+        print "New in " version ":"
+        print ""
+        next
+      }
+      { print }
+    ' NEWS > "${tmp_file}"
+    mv "${tmp_file}" NEWS
+    print -- "Added NEWS section for ${develop_version}."
+  fi
+  print -- "Review the diff, then commit and push the post-release development bump."
+else
+  print -- "Dry run only. These commands would prepare the next development cycle:"
+  print -- "  scripts/release/prepare.zsh --apply '${develop_version}'"
+  print -- "  ensure NEWS starts with 'New in ${develop_version}:'"
+  print -- "  git add CMakeLists.txt m4/fswatch_version.m4 m4/libfswatch_version.m4 NEWS"
+  print -- "  git commit -m 'Bump version to ${develop_version}'"
+  print -- "  git push origin master"
+fi

--- a/scripts/release/prepare.zsh
+++ b/scripts/release/prepare.zsh
@@ -1,0 +1,135 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+PROGNAME=${0:t}
+PROGDIR=${0:A:h}
+
+. "${PROGDIR}/lib.zsh"
+
+usage()
+{
+  print -- "Usage: ${PROGNAME} [--apply] VERSION"
+  print
+  print -- "Prepare version files for VERSION."
+  print -- "Without --apply, only print the edits that would be made."
+  print
+  print -- "VERSION may be X.Y.Z, X.Y.Z-rcN, or X.Y.Z-develop."
+}
+
+typeset -i apply=0
+
+while (( $# > 0 ))
+do
+  case "$1" in
+    --apply)
+      apply=1
+      shift
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      release_die "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+(( $# == 1 )) || {
+  usage
+  exit 1
+}
+
+release_parse_version "$1"
+
+repo_root=$(release_repo_root)
+cd "${repo_root}"
+
+print -- "Version file preparation:"
+print -- "  FSWATCH_VERSION=${RELEASE_VERSION}"
+print -- "  LIBFSWATCH_VERSION=${RELEASE_VERSION}"
+print -- "  CMake project version=${RELEASE_BASE_VERSION}"
+print -- "  CMake VERSION_MODIFIER=${RELEASE_VERSION_MODIFIER}"
+
+if (( ! apply ))
+then
+  print -- "Dry run only. Re-run with --apply to edit files."
+  exit 0
+fi
+
+tmp_file=m4/fswatch_version.m4.tmp.$$
+awk -v value="${RELEASE_VERSION}" '
+  /^m4_define\(\[FSWATCH_VERSION\], \[/ {
+    print "m4_define([FSWATCH_VERSION], [" value "])"
+    next
+  }
+  { print }
+' m4/fswatch_version.m4 > "${tmp_file}"
+mv "${tmp_file}" m4/fswatch_version.m4
+
+tmp_file=m4/libfswatch_version.m4.tmp.$$
+awk -v value="${RELEASE_VERSION}" '
+  /^m4_define\(\[LIBFSWATCH_VERSION\], \[/ {
+    print "m4_define([LIBFSWATCH_VERSION], [" value "])"
+    next
+  }
+  { print }
+' m4/libfswatch_version.m4 > "${tmp_file}"
+mv "${tmp_file}" m4/libfswatch_version.m4
+
+tmp_file=CMakeLists.txt.tmp.$$
+awk -v base="${RELEASE_BASE_VERSION}" -v modifier="${RELEASE_VERSION_MODIFIER}" '
+  /^project\(fswatch VERSION / {
+    print "project(fswatch VERSION " base " LANGUAGES C CXX)"
+    next
+  }
+  /^set\(VERSION_MODIFIER / {
+    print "set(VERSION_MODIFIER \"" modifier "\")"
+    next
+  }
+  { print }
+' CMakeLists.txt > "${tmp_file}"
+mv "${tmp_file}" CMakeLists.txt
+
+[[ "$(release_m4_define m4/fswatch_version.m4 FSWATCH_VERSION)" == "${RELEASE_VERSION}" ]] ||
+  release_die "failed to update FSWATCH_VERSION"
+[[ "$(release_m4_define m4/libfswatch_version.m4 LIBFSWATCH_VERSION)" == "${RELEASE_VERSION}" ]] ||
+  release_die "failed to update LIBFSWATCH_VERSION"
+[[ "$(release_cmake_project_version)" == "${RELEASE_BASE_VERSION}" ]] ||
+  release_die "failed to update CMake project version"
+[[ "$(release_cmake_version_modifier)" == "${RELEASE_VERSION_MODIFIER}" ]] ||
+  release_die "failed to update CMake VERSION_MODIFIER"
+
+print -- "Updated version files. Review LIBFSWATCH_API_VERSION and changelogs manually."

--- a/scripts/release/publish.zsh
+++ b/scripts/release/publish.zsh
@@ -1,0 +1,141 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+PROGNAME=${0:t}
+PROGDIR=${0:A:h}
+
+. "${PROGDIR}/lib.zsh"
+
+usage()
+{
+  print -- "Usage: ${PROGNAME} [options] VERSION"
+  print
+  print -- "Create the release tag and GitHub release. Defaults to dry-run."
+  print
+  print -- "Options:"
+  print -- "  --execute        Actually create/push the tag and create the GitHub release."
+  print -- "  --notes FILE     Release notes file. Default: release-notes.md."
+  print -- "  --repo OWNER/REPO GitHub repository. Default: ${RELEASE_REPO}."
+  print -- "  -h, --help       Print this message."
+}
+
+typeset -i execute=0
+notes_file=release-notes.md
+repo=${RELEASE_REPO}
+
+while (( $# > 0 ))
+do
+  case "$1" in
+    --execute)
+      execute=1
+      shift
+      ;;
+    --dry-run)
+      execute=0
+      shift
+      ;;
+    --notes)
+      (( $# >= 2 )) || release_die "--notes requires a file"
+      notes_file=$2
+      shift 2
+      ;;
+    --repo)
+      (( $# >= 2 )) || release_die "--repo requires OWNER/REPO"
+      repo=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      release_die "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+(( $# == 1 )) || {
+  usage
+  exit 1
+}
+
+release_parse_version "$1"
+(( ! RELEASE_IS_DEVELOP )) ||
+  release_die "publish refuses -develop versions"
+
+repo_root=$(release_repo_root)
+cd "${repo_root}"
+
+[[ -f "${notes_file}" ]] ||
+  release_die "release notes file does not exist: ${notes_file}"
+
+release_flags=()
+if (( RELEASE_IS_PRERELEASE ))
+then
+  release_flags+=( --prerelease --latest=false )
+fi
+
+print -- "Publish plan for ${RELEASE_VERSION}:"
+print -- "  repository: ${repo}"
+print -- "  notes: ${notes_file}"
+print -- "  prerelease: ${RELEASE_IS_PRERELEASE}"
+print -- "  assets: produced later by .github/workflows/release-tarball.yml"
+
+if (( ! execute ))
+then
+  print
+  print -- "Dry run only. These commands would run:"
+  print -- "  scripts/release/check.zsh --release --require-clean --notes '${notes_file}' '${RELEASE_VERSION}'"
+  print -- "  git tag -a '${RELEASE_VERSION}' -m '${RELEASE_VERSION}'   # only if the tag does not exist"
+  print -- "  git push origin '${RELEASE_VERSION}'"
+  print -- "  gh release create '${RELEASE_VERSION}' --repo '${repo}' --verify-tag --title 'fswatch v. ${RELEASE_VERSION}' --notes-file '${notes_file}' ${release_flags[*]}"
+  exit 0
+fi
+
+"${PROGDIR}/check.zsh" --release --require-clean --notes "${notes_file}" "${RELEASE_VERSION}"
+
+if release_tag_exists "${RELEASE_VERSION}"
+then
+  tag_type=$(release_tag_type "${RELEASE_VERSION}")
+  [[ "${tag_type}" == "tag" ]] ||
+    release_die "local tag ${RELEASE_VERSION} exists but is '${tag_type}', not an annotated tag"
+else
+  git tag -a "${RELEASE_VERSION}" -m "${RELEASE_VERSION}"
+fi
+
+git push origin "${RELEASE_VERSION}"
+
+gh release create "${RELEASE_VERSION}" \
+  --repo "${repo}" \
+  --verify-tag \
+  --title "fswatch v. ${RELEASE_VERSION}" \
+  --notes-file "${notes_file}" \
+  "${release_flags[@]}"

--- a/scripts/release/test.zsh
+++ b/scripts/release/test.zsh
@@ -36,8 +36,8 @@ usage()
   print -- "Options:"
   print -- "  --release VERSION       Simulated release version. Default: 1.19.0."
   print -- "  --next VERSION          Simulated next development version. Default: 1.20.0."
-  print -- "  --dist                  Also run autogen, configure, and make dist."
-  print -- "  --distcheck             Also run autogen, configure, and make distcheck."
+  print -- "  --dist                  Also run autogen, configure, and make -j dist."
+  print -- "  --distcheck             Also run autogen, configure, and make -j distcheck."
   print -- "  --keep-worktree         Keep the temporary worktree for inspection."
   print -- "  -h, --help              Print this message."
 }
@@ -139,15 +139,26 @@ print -- "Checking current development metadata."
 current_version=$(release_m4_define m4/fswatch_version.m4 FSWATCH_VERSION)
 scripts/release/check.zsh "${current_version}"
 
-print -- "Checking expected release-guard failures."
-if scripts/release/check.zsh --release "${current_version}" > release-check-develop.log 2>&1
+release_parse_version "${current_version}"
+current_is_develop=${RELEASE_IS_DEVELOP}
+
+print -- "Checking release guards."
+if (( current_is_develop ))
 then
-  release_die "--release unexpectedly accepted ${current_version}"
+  if scripts/release/check.zsh --release "${current_version}" > release-check-develop.log 2>&1
+  then
+    release_die "--release unexpectedly accepted ${current_version}"
+  fi
+else
+  scripts/release/check.zsh --release "${current_version}" > /dev/null
 fi
 
-if scripts/release/check.zsh --release "${release_version}" > release-check-unprepared.log 2>&1
+if [[ "${current_version}" != "${release_version}" ]]
 then
-  release_die "unprepared release check unexpectedly passed for ${release_version}"
+  if scripts/release/check.zsh --release "${release_version}" > release-check-unprepared.log 2>&1
+  then
+    release_die "unprepared release check unexpectedly passed for ${release_version}"
+  fi
 fi
 
 print -- "Running dry-run helpers."
@@ -195,15 +206,15 @@ fi
 
 if (( run_dist ))
 then
-  print -- "Running make dist."
-  make dist
+  print -- "Running make -j dist."
+  make -j dist
   scripts/release/check.zsh --release --require-dist "${release_version}"
 fi
 
 if (( run_distcheck ))
 then
-  print -- "Running make distcheck."
-  make distcheck
+  print -- "Running make -j distcheck."
+  make -j distcheck
   scripts/release/check.zsh --release --require-dist "${release_version}"
 fi
 

--- a/scripts/release/test.zsh
+++ b/scripts/release/test.zsh
@@ -1,0 +1,214 @@
+#!/bin/zsh
+# -*- vim:fenc=utf-8:et:sw=2:ts=2:sts=2
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+setopt local_options
+setopt local_traps
+unsetopt glob_subst
+
+set -o errexit
+set -o nounset
+
+PROGNAME=${0:t}
+PROGDIR=${0:A:h}
+
+. "${PROGDIR}/lib.zsh"
+
+usage()
+{
+  print -- "Usage: ${PROGNAME} [options]"
+  print
+  print -- "Run non-publishing tests for the release automation."
+  print
+  print -- "Options:"
+  print -- "  --release VERSION       Simulated release version. Default: 1.19.0."
+  print -- "  --next VERSION          Simulated next development version. Default: 1.20.0."
+  print -- "  --dist                  Also run autogen, configure, and make dist."
+  print -- "  --distcheck             Also run autogen, configure, and make distcheck."
+  print -- "  --keep-worktree         Keep the temporary worktree for inspection."
+  print -- "  -h, --help              Print this message."
+}
+
+release_version=1.19.0
+next_version=1.20.0
+typeset -i run_dist=0
+typeset -i run_distcheck=0
+typeset -i keep_worktree=0
+
+while (( $# > 0 ))
+do
+  case "$1" in
+    --release)
+      (( $# >= 2 )) || release_die "--release requires VERSION"
+      release_version=$2
+      shift 2
+      ;;
+    --next)
+      (( $# >= 2 )) || release_die "--next requires VERSION"
+      next_version=$2
+      shift 2
+      ;;
+    --dist)
+      run_dist=1
+      shift
+      ;;
+    --distcheck)
+      run_distcheck=1
+      shift
+      ;;
+    --keep-worktree)
+      keep_worktree=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      release_die "unknown option: $1"
+      ;;
+    *)
+      release_die "unexpected argument: $1"
+      ;;
+  esac
+done
+
+release_parse_version "${release_version}"
+(( ! RELEASE_IS_DEVELOP )) ||
+  release_die "--release must be a releasable version, not -develop"
+
+release_parse_version "${next_version}"
+[[ -z "${RELEASE_VERSION_MODIFIER}" ]] ||
+  release_die "--next must be numeric X.Y.Z"
+
+repo_root=$(release_repo_root)
+cd "${repo_root}"
+
+tmp_parent=$(mktemp -d /tmp/fswatch-release-test.XXXXXX)
+tmp_worktree="${tmp_parent}/worktree"
+
+cleanup()
+{
+  local exit_status=$?
+
+  if (( keep_worktree ))
+  then
+    print -- "Kept temporary worktree: ${tmp_worktree}"
+    print -- "Remove it with: git worktree remove '${tmp_worktree}'"
+  else
+    git worktree remove --force "${tmp_worktree}" > /dev/null 2>&1 || true
+    rm -rf "${tmp_parent}"
+  fi
+
+  exit ${exit_status}
+}
+
+trap cleanup EXIT INT TERM
+
+print -- "Creating temporary worktree: ${tmp_worktree}"
+git worktree add --detach --quiet "${tmp_worktree}" HEAD
+
+print -- "Overlaying current release scripts into temporary worktree."
+rm -rf "${tmp_worktree}/scripts/release"
+mkdir -p "${tmp_worktree}/scripts"
+cp -R "${repo_root}/scripts/release" "${tmp_worktree}/scripts/"
+
+cd "${tmp_worktree}"
+
+print -- "Running shell syntax checks."
+zsh -n scripts/release/*.zsh
+
+print -- "Checking current development metadata."
+current_version=$(release_m4_define m4/fswatch_version.m4 FSWATCH_VERSION)
+scripts/release/check.zsh "${current_version}"
+
+print -- "Checking expected release-guard failures."
+if scripts/release/check.zsh --release "${current_version}" > release-check-develop.log 2>&1
+then
+  release_die "--release unexpectedly accepted ${current_version}"
+fi
+
+if scripts/release/check.zsh --release "${release_version}" > release-check-unprepared.log 2>&1
+then
+  release_die "unprepared release check unexpectedly passed for ${release_version}"
+fi
+
+print -- "Running dry-run helpers."
+scripts/release/prepare.zsh "${release_version}" > /dev/null
+scripts/release/post-release.zsh "${next_version}" > /dev/null
+
+print -- "Preparing simulated release ${release_version}."
+scripts/release/prepare.zsh --apply "${release_version}"
+
+tmp_news=NEWS.tmp.$$
+awk -v version="${release_version}" -v old_version="${current_version}" '
+  NR == 1 { print; next }
+  NR == 2 {
+    print
+    print ""
+    print "New in " version ":"
+    print ""
+    next
+  }
+  $0 == "New in " old_version ":" { next }
+  { print }
+' NEWS > "${tmp_news}"
+mv "${tmp_news}" NEWS
+
+scripts/release/check.zsh "${release_version}"
+
+print -- "Generating and validating release notes."
+scripts/release/notes.zsh --output release-notes.md "${release_version}"
+scripts/release/check.zsh --release --notes release-notes.md "${release_version}"
+
+print -- "Checking tarball-name validation with a dummy file."
+touch "fswatch-${release_version}.tar.gz"
+scripts/release/check.zsh --release --require-dist "${release_version}"
+rm "fswatch-${release_version}.tar.gz"
+
+print -- "Checking publish dry-run."
+scripts/release/publish.zsh --notes release-notes.md "${release_version}" > publish-dry-run.log
+
+if (( run_dist || run_distcheck ))
+then
+  print -- "Bootstrapping and configuring the temporary release worktree."
+  ./autogen.sh
+  CC=${CC:-gcc} CXX=${CXX:-g++} ./configure
+fi
+
+if (( run_dist ))
+then
+  print -- "Running make dist."
+  make dist
+  scripts/release/check.zsh --release --require-dist "${release_version}"
+fi
+
+if (( run_distcheck ))
+then
+  print -- "Running make distcheck."
+  make distcheck
+  scripts/release/check.zsh --release --require-dist "${release_version}"
+fi
+
+print -- "Preparing simulated post-release development version ${next_version}-develop."
+scripts/release/post-release.zsh --apply "${next_version}"
+scripts/release/check.zsh "${next_version}-develop"
+
+print -- "Release automation tests passed."


### PR DESCRIPTION
## Summary

This PR adds a deterministic release automation harness and documents the release process for `fswatch`.

The goal is to make release preparation reproducible while keeping the judgment-heavy parts explicit: NEWS updates, libtool version review, and final maintainer approval.

## Changes

- Add release helper scripts under `scripts/release/`:
  - `check.zsh` validates release metadata, clean tree state, release notes, and expected tarball names.
  - `prepare.zsh` updates Autotools and CMake version metadata.
  - `notes.zsh` generates a GitHub release-note draft from `NEWS` and `NEWS.libfswatch`.
  - `publish.zsh` dry-runs or executes tag creation, tag push, and GitHub release creation.
  - `post-release.zsh` prepares the next `-develop` version after a release.
  - `test.zsh` exercises the release automation non-destructively in a temporary git worktree.

- Update `.github/workflows/release-tarball.yml`:
  - Check out the release tag explicitly.
  - Resolve annotated tags to their target commit before checking the `autotools` status.
  - Validate release metadata before packaging.
  - Run `make -j distcheck`.
  - Validate the generated release tarball name before uploading assets.
  - Build PDF documentation with parallel `make`.

- Ignore generated local release-note drafts:
  - Add `release-notes.md` to `.gitignore`.

## Notes

This branch currently also contains a temporary `1.19.0-rc1` version bump and NEWS update used to test the release flow. That is useful for validating the automation, but it should be reviewed carefully before merge because release version bumps should normally happen from an up-to-date `master` as part of the actual release preparation flow.

## Validation

Ran the release automation harness successfully:

```sh
scripts/release/test.zsh
```

Previously also validated the extended local packaging path with:

```sh
scripts/release/test.zsh --distcheck
```

The harness exercises release metadata validation, dry-run publish behavior, simulated release preparation, release-note generation, tarball-name validation, and simulated post-release development bumping without publishing anything.