### PR TITLE
Bump v. 1.19.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(fswatch VERSION 1.19.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-rc1")
+set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 NEWS
 ****
 
-New in 1.19.0-rc1:
+New in 1.19.0:
 
   * PR 353, Issue 343: Fix a segmentation fault in the macOS FSEvents monitor
     when file event metadata does not include an inode.

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,7 +1,7 @@
 NEWS
 ****
 
-New in 1.19.0-rc1:
+New in 1.19.0:
 
   * PR 353, Issue 343: Fix a segmentation fault in the macOS FSEvents monitor
     when file event metadata does not include an inode.

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.19.0-rc1])
+m4_define([FSWATCH_VERSION], [1.19.0])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.19.0-rc1])
+m4_define([LIBFSWATCH_VERSION], [1.19.0])
 m4_define([LIBFSWATCH_API_VERSION], [13:2:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,7 +30,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.19.0-rc1\n"
+"Project-Id-Version: fswatch 1.19.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: 2026-04-11 22:37+0200\n"

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,7 +27,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.19.0-rc1\n"
+"Project-Id-Version: fswatch 1.19.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: 2026-04-11 22:37+0200\n"

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.19.0-rc1\n"
+"Project-Id-Version: fswatch 1.19.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-11 22:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
## Summary

Prepare the final `1.19.0` release after validating `1.19.0-rc1` end to end.

## Changes

- Remove the `-rc1` modifier from Autotools and CMake release metadata.
- Retitle the top `NEWS` and `NEWS.libfswatch` sections from `1.19.0-rc1` to `1.19.0`.
- Refresh gettext project version headers for the final release version.

## Release Review

- `LIBFSWATCH_API_VERSION` remains `13:2:0`.
- Rationale: the final release changes only version strings and changelog headings relative to the RC. The libfswatch API/ABI review performed for `1.19.0-rc1` still applies.

## Validation

```sh
make -j distcheck
scripts/release/check.zsh --release --require-libfswatch-news --require-dist --notes release-notes.md 1.19.0
scripts/release/check.zsh --release --require-libfswatch-news --notes release-notes.md 1.19.0
```

The generated local tarball was `fswatch-1.19.0.tar.gz`.