### PR TITLE
Fix GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build:
     strategy:
@@ -16,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies on Ubuntu
       if: matrix.os == 'ubuntu-latest'
@@ -47,10 +51,10 @@ jobs:
       run: make check
 
     - name: Set commit status
-      uses: actions/github-script@v4
+      uses: actions/github-script@v8
       with:
         script: |
-          github.repos.createCommitStatus({
+          github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
             sha: context.sha,

--- a/.github/workflows/cmake-libfswatch.yml
+++ b/.github/workflows/cmake-libfswatch.yml
@@ -19,20 +19,51 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: r-lib/actions/setup-r@v2
+    - uses: actions/checkout@v5
+
+    - name: Install MSYS2 MinGW toolchain
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $msys2 = 'C:\msys64'
+
+        if (-not (Test-Path "$msys2\usr\bin\bash.exe")) {
+          choco install msys2 --no-progress -y
+        }
+
+        & "$msys2\usr\bin\bash.exe" -lc 'pacman --noconfirm -Sy --needed mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-ninja'
+
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        "$msys2\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        "$msys2\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_LIBS_ONLY=1
+      shell: pwsh
+      run: |
+        cmake `
+          -G Ninja `
+          -B "${{ github.workspace }}/build" `
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} `
+          -DBUILD_LIBS_ONLY=1
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      shell: pwsh
+      run: |
+        cmake `
+          --build "${{ github.workspace }}/build" `
+          --config "${{ env.BUILD_TYPE }}"
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      shell: pwsh
+      run: |
+        ctest `
+          --test-dir "${{ github.workspace }}/build" `
+          -C "${{ env.BUILD_TYPE }}"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -4,24 +4,28 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+  statuses: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.event.release.tag_name }}
 
     - name: Check autotools status
       id: check_status
-      uses: actions/github-script@v4
+      uses: actions/github-script@v8
       with:
         script: |
           const owner = context.repo.owner;
           const repo = context.repo.repo;
           const tagName = context.payload.release.tag_name;
-          const tagRef = await github.git.getRef({
+          const tagRef = await github.rest.git.getRef({
             owner,
             repo,
             ref: `tags/${tagName}`
@@ -29,7 +33,7 @@ jobs:
 
           let releaseCommit = tagRef.data.object.sha;
           if (tagRef.data.object.type === 'tag') {
-            const tag = await github.git.getTag({
+            const tag = await github.rest.git.getTag({
               owner,
               repo,
               tag_sha: releaseCommit
@@ -37,7 +41,7 @@ jobs:
             releaseCommit = tag.data.object.sha;
           }
 
-          const status = await github.repos.getCombinedStatusForRef({
+          const status = await github.rest.repos.getCombinedStatusForRef({
             owner,
             repo,
             ref: releaseCommit
@@ -70,24 +74,24 @@ jobs:
       run: scripts/release/check.zsh --release --require-dist ${{ github.event.release.tag_name }}
 
     - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./fswatch-${{ github.event.release.tag_name }}.tar.gz
-        asset_name: fswatch-${{ github.event.release.tag_name }}.tar.gz
-        asset_content_type: application/gzip
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ github.event.release.tag_name }}
+      run: |
+        gh release upload "${TAG_NAME}" \
+          "./fswatch-${TAG_NAME}.tar.gz#fswatch-${TAG_NAME}.tar.gz" \
+          --repo "${GITHUB_REPOSITORY}" \
+          --clobber
 
     - name: Build PDF documentation
       run: make -j pdf
 
     - name: Upload Release PDF documentation
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./fswatch/doc/fswatch.pdf
-        asset_name: fswatch-${{ github.event.release.tag_name }}.pdf
-        asset_content_type: application/gzip
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ github.event.release.tag_name }}
+      run: |
+        gh release upload "${TAG_NAME}" \
+          "./fswatch/doc/fswatch.pdf#fswatch-${TAG_NAME}.pdf" \
+          --repo "${GITHUB_REPOSITORY}" \
+          --clobber


### PR DESCRIPTION
## Summary

Fix the GitHub Actions warnings seen during the 1.19.0 release flow.

## Changes

- Upgrade official GitHub JavaScript actions to Node 24-compatible versions:
  - `actions/checkout@v5`
  - `actions/github-script@v8`
- Update `github-script` calls to the current `github.rest.*` API shape.
- Replace `actions/upload-release-asset@v1` with `gh release upload` commands to remove the deprecated `set-output` usage.
- Replace `r-lib/actions/setup-r@v2` in the Windows MinGW workflow with an explicit MSYS2 MinGW toolchain setup step.
- Add explicit workflow permissions where status creation or release uploads require them.

## Validation

- Parsed all workflow YAML files locally with Ruby YAML.
- Confirmed the workflow files no longer reference `actions/upload-release-asset`, `setup-r`, `set-output`, or older checkout/github-script action versions.

The PR checks are the real validation gate for the Windows MSYS2 change and the updated action versions.