### PR TITLE
Fix inotify access event filtering

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ NEWS
 
 New in 1.20.0-develop:
 
+  * Issue 352: inotify no longer reports access, open, or close-without-write
+    events unless access events are enabled with -a or --access.
+
 
 New in 1.19.0:
 

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -105,9 +105,15 @@ namespace fsw
   bool inotify_monitor::add_watch(const std::string& path)
   {
     // TODO: Consider optionally adding the IN_EXCL_UNLINK flag.
+    auto event_mask = IN_ALL_EVENTS;
+    if (!watch_access)
+    {
+      event_mask &= ~(IN_ACCESS | IN_CLOSE_NOWRITE | IN_OPEN);
+    }
+
     int inotify_desc = inotify_add_watch(impl->inotify_monitor_handle,
                                          path.c_str(),
-                                         IN_ALL_EVENTS);
+                                         event_mask);
 
     if (inotify_desc == -1)
     {

--- a/test/inotify_access_events.sh
+++ b/test/inotify_access_events.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+#
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 FSWATCH" >&2
+  exit 2
+fi
+
+FSWATCH=$1
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-access.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+TESTDIR="${WORKDIR}/watched"
+TESTFILE="${TESTDIR}/file.txt"
+mkdir "${TESTDIR}"
+echo "content" > "${TESTFILE}"
+
+start_fswatch() {
+  access_flag=$1
+
+  : > "${WORKDIR}/out.log"
+  : > "${WORKDIR}/err.log"
+
+  if [ -n "${access_flag}" ]; then
+    "${FSWATCH}" -m inotify_monitor -rx "${access_flag}" --event PlatformSpecific "${TESTDIR}" \
+      > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+  else
+    "${FSWATCH}" -m inotify_monitor -rx --event PlatformSpecific "${TESTDIR}" \
+      > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+  fi
+  PID=$!
+
+  sleep 1
+}
+
+stop_fswatch() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+    PID=
+  fi
+}
+
+print_logs() {
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,80p' "${WORKDIR}/err.log" >&2
+}
+
+start_fswatch ""
+ls "${TESTDIR}" >/dev/null
+cat "${TESTFILE}" >/dev/null
+sleep 1
+stop_fswatch
+
+if [ -s "${WORKDIR}/out.log" ]; then
+  echo "read-only operations produced access events without --access" >&2
+  print_logs
+  exit 1
+fi
+
+start_fswatch "-a"
+found=
+attempt=0
+
+while [ "${attempt}" -lt 8 ]; do
+  cat "${TESTFILE}" >/dev/null
+
+  if grep -q 'PlatformSpecific' "${WORKDIR}/out.log"; then
+    found=1
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+stop_fswatch
+
+if [ -z "${found}" ]; then
+  echo "missing access event when --access is specified" >&2
+  print_logs
+  exit 1
+fi

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -26,15 +26,25 @@ if (BUILD_TESTING)
     find_program(SH_EXECUTABLE sh)
     find_program(GIT_EXECUTABLE git)
 
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SH_EXECUTABLE AND GIT_EXECUTABLE)
-        add_test(NAME inotify_recursive_create
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SH_EXECUTABLE)
+        add_test(NAME inotify_access_events
                 COMMAND ${SH_EXECUTABLE}
-                        ${PROJECT_SOURCE_DIR}/test/inotify_recursive_create.sh
-                        $<TARGET_FILE:fswatch>
-                        ${GIT_EXECUTABLE})
-        set_tests_properties(inotify_recursive_create PROPERTIES
+                        ${PROJECT_SOURCE_DIR}/test/inotify_access_events.sh
+                        $<TARGET_FILE:fswatch>)
+        set_tests_properties(inotify_access_events PROPERTIES
                 LABELS "integration;inotify"
                 TIMEOUT 15)
+
+        if (GIT_EXECUTABLE)
+            add_test(NAME inotify_recursive_create
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_recursive_create.sh
+                            $<TARGET_FILE:fswatch>
+                            ${GIT_EXECUTABLE})
+            set_tests_properties(inotify_recursive_create PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 15)
+        endif ()
     endif ()
 
     if (APPLE)


### PR DESCRIPTION
## Summary

Fixes #352.

The Linux inotify monitor was subscribing with `IN_ALL_EVENTS`, which includes access-only events such as `IN_ACCESS`, `IN_OPEN`, and `IN_CLOSE_NOWRITE`. Those events were mapped to `PlatformSpecific`, so read-only operations could trigger fswatch output even when `-a` / `--access` was not specified.

This change keeps the inotify monitor based on `IN_ALL_EVENTS`, but clears those access-only masks unless access watching is explicitly enabled.

## Tests

Added a Linux CTest integration test covering both sides of the contract:

- without `-a`, read-only `ls` / `cat` operations produce no `PlatformSpecific` output;
- with `-a`, read access still produces `PlatformSpecific` events.

Validation run:

```sh
ctest --test-dir /tmp/fswatch-build -R 'inotify_(recursive_create|access_events)' --output-on-failure
```