### PR TITLE
Aggregate autotools status across matrix

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,11 +8,11 @@ on:
 
 permissions:
   contents: read
-  statuses: write
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         configuration: [ Release, Debug ]
@@ -50,16 +50,37 @@ jobs:
     - name: Run checks
       run: make check
 
-    - name: Set commit status
+  autotools:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+    - name: Report autotools result
       uses: actions/github-script@v8
       with:
         script: |
-          github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: context.sha,
-            state: 'success',
-            context: 'autotools',
-            description: 'Autotools build successful',
-            target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-          })
+          const buildResult = '${{ needs.build.result }}';
+          const state = buildResult === 'success' ? 'success' : 'failure';
+          const description = state === 'success'
+            ? 'Autotools matrix successful'
+            : `Autotools matrix ${buildResult}`;
+
+          if (context.eventName === 'push' && context.ref === 'refs/heads/master') {
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state,
+              context: 'autotools',
+              description,
+              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            });
+          }
+
+          if (state !== 'success') {
+            core.setFailed(description);
+          }


### PR DESCRIPTION
Closes #360.

This changes the Autotools CI workflow so the custom `autotools` commit status is reported once, after the full matrix has completed, instead of once per matrix cell.

The aggregate job still fails the PR check when any matrix cell fails, but it only writes the custom commit status for pushes to `master`. That keeps fork pull requests from failing on a read-only `GITHUB_TOKEN` while preserving the release workflow precondition: release artifacts are uploaded only when the tagged commit has `autotools: success`.

Validation performed locally:

- Parsed `.github/workflows/c-cpp.yml` and `.github/workflows/release-tarball.yml` with PyYAML.
- Ran `git diff --check`.