### PR TITLE
Prepare release 1.19.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.20.0 LANGUAGES C CXX)
+project(fswatch VERSION 1.19.1 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-develop")
+set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,10 @@
 NEWS
 ****
 
-New in 1.20.0-develop:
+New in 1.19.1:
+
+  * PR 350, Issue 349: Fix latency values lower than one second in the Windows
+    monitor.
 
   * Issue 352: inotify no longer reports access, open, or close-without-write
     events unless access events are enabled with -a or --access.

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,6 +1,14 @@
 NEWS
 ****
 
+New in 1.19.1:
+
+  * PR 350, Issue 349: Fix latency values lower than one second in the Windows
+    monitor.
+
+  * Issue 352: inotify no longer reports access, open, or close-without-write
+    events unless access events are enabled with -a or --access.
+
 New in 1.19.0:
 
   * PR 353, Issue 343: Fix a segmentation fault in the macOS FSEvents monitor

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.20.0-develop])
+m4_define([FSWATCH_VERSION], [1.19.1])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.20.0-develop])
-m4_define([LIBFSWATCH_API_VERSION], [13:2:0])
+m4_define([LIBFSWATCH_VERSION], [1.19.1])
+m4_define([LIBFSWATCH_API_VERSION], [13:3:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/scripts/release/prepare.zsh
+++ b/scripts/release/prepare.zsh
@@ -133,3 +133,4 @@ mv "${tmp_file}" CMakeLists.txt
   release_die "failed to update CMake VERSION_MODIFIER"
 
 print -- "Updated version files. Review LIBFSWATCH_API_VERSION and changelogs manually."
+print -- "When a changelog item comes from a GitHub PR or issue, include those numbers."


### PR DESCRIPTION
Prepares fswatch 1.19.1 release metadata.

Changes:

- Set fswatch/libfswatch versions to 1.19.1.
- Set CMake project version to 1.19.1 and clear the development modifier.
- Update NEWS and NEWS.libfswatch for the 1.19.1 bug fixes.
- Bump libfswatch libtool version-info from 13:2:0 to 13:3:0.
- Clarify release-prep script guidance to include PR/issue numbers in changelog entries when available.

Validation performed locally:

- scripts/release/notes.zsh -o release-notes.md 1.19.1
- scripts/release/check.zsh --release --notes release-notes.md 1.19.1
- git diff --check