### PR TITLE
Bump version to 1.20.0-develop

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -91,7 +91,8 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG_NAME: ${{ github.event.release.tag_name }}
       run: |
+        cp ./fswatch/doc/fswatch.pdf "./fswatch-${TAG_NAME}.pdf"
         gh release upload "${TAG_NAME}" \
-          "./fswatch/doc/fswatch.pdf#fswatch-${TAG_NAME}.pdf" \
+          "./fswatch-${TAG_NAME}.pdf" \
           --repo "${GITHUB_REPOSITORY}" \
           --clobber

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.19.1 LANGUAGES C CXX)
+project(fswatch VERSION 1.20.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "")
+set(VERSION_MODIFIER "-develop")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 NEWS
 ****
 
+New in 1.20.0-develop:
+
+
 New in 1.19.1:
 
   * PR 350, Issue 349: Fix latency values lower than one second in the Windows

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.19.1])
+m4_define([FSWATCH_VERSION], [1.20.0-develop])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.19.1])
+m4_define([LIBFSWATCH_VERSION], [1.20.0-develop])
 m4_define([LIBFSWATCH_API_VERSION], [13:3:0])
 m4_define([LIBFSWATCH_REVISION], [1])


### PR DESCRIPTION
Post-release follow-up after publishing fswatch 1.19.1.

Changes:

- Restore fswatch/libfswatch versions to 1.20.0-develop.
- Add a new NEWS section for 1.20.0-develop.
- Fix the release-tarball workflow PDF upload so the asset name is fswatch-<version>.pdf rather than only using that text as the asset label.

Validation performed locally:

- scripts/release/check.zsh 1.20.0-develop
- Parsed .github/workflows/release-tarball.yml with Ruby YAML.
- git diff --check