### PR TITLE
Refactor inotify monitor wait loop to use epoll wakeups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ fswatch_test
 *.o
 cmake-build-debug/
 build/
+build-inotify-soak/
+build-sanitize/
 dist/
 
 # Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ docker/debian-testing/Dockerfile
 
 # Output files
 man/fswatch.7
+test/*_test
 test/*.log
 test/*.trs
 test/test-suite.log

--- a/configure.ac
+++ b/configure.ac
@@ -173,22 +173,31 @@ AS_VAR_IF([ac_cv_header_port_h], ["yes"], [
 AM_CONDITIONAL([USE_FEN], [test "x${FEN_AVAILABLE}" = "xyes"])
 
 # Check for Linux inotify.
-AC_CHECK_HEADERS([sys/inotify.h])
-AS_VAR_IF([ac_cv_header_sys_inotify_h], ["yes"], [
+AC_CHECK_HEADERS([sys/inotify.h sys/epoll.h sys/eventfd.h])
+AS_IF([test "x${ac_cv_header_sys_inotify_h}" = "xyes" \
+       && test "x${ac_cv_header_sys_epoll_h}" = "xyes" \
+       && test "x${ac_cv_header_sys_eventfd_h}" = "xyes"], [
   AS_VAR_SET([INOTIFY_AVAILABLE], ["yes"])
   AC_CHECK_DECLS(
-    [inotify_init, inotify_add_watch, inotify_rm_watch],
+    [inotify_init1, inotify_add_watch, inotify_rm_watch,
+     epoll_create1, epoll_ctl, epoll_wait, eventfd],
     [],
     [AS_VAR_SET([INOTIFY_AVAILABLE], ["no"])],
     [
+      [#ifndef _GNU_SOURCE]
+      [#  define _GNU_SOURCE]
+      [#endif]
       AC_INCLUDES_DEFAULT
       [#include <sys/inotify.h>]
+      [#include <sys/epoll.h>]
+      [#include <sys/eventfd.h>]
     ]
   )
-  AC_CHECK_LIB([c], [inotify_init], [], [AS_VAR_SET([INOTIFY_AVAILABLE], ["no"])])
+  AC_CHECK_LIB([c], [inotify_init1], [], [AS_VAR_SET([INOTIFY_AVAILABLE], ["no"])])
 ])
 
 AM_CONDITIONAL([USE_INOTIFY],  [test "x${INOTIFY_AVAILABLE}" = "xyes"])
+AS_VAR_IF([INOTIFY_AVAILABLE], ["yes"], [AC_DEFINE([HAVE_INOTIFY_MONITOR], [1], [Linux inotify monitor available.])])
 
 # Check for Linux fanotify.
 AC_CHECK_HEADERS([sys/fanotify.h sys/epoll.h sys/eventfd.h])

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -78,15 +78,28 @@ check_struct_has_member("struct stat" st_mtime sys/stat.h HAVE_STRUCT_STAT_ST_MT
 check_struct_has_member("struct stat" st_mtimespec sys/stat.h HAVE_STRUCT_STAT_ST_MTIMESPEC)
 
 check_include_file_cxx(sys/inotify.h HAVE_SYS_INOTIFY_H)
+check_include_file_cxx(sys/epoll.h HAVE_SYS_EPOLL_H)
+check_include_file_cxx(sys/eventfd.h HAVE_SYS_EVENTFD_H)
 
-if (HAVE_SYS_INOTIFY_H)
+if (HAVE_SYS_INOTIFY_H AND HAVE_SYS_EPOLL_H AND HAVE_SYS_EVENTFD_H)
+    set(CMAKE_REQUIRED_DEFINITIONS_SAVED ${CMAKE_REQUIRED_DEFINITIONS})
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    check_cxx_symbol_exists(inotify_init1 sys/inotify.h HAVE_INOTIFY_INIT1)
+    check_cxx_symbol_exists(epoll_create1 sys/epoll.h HAVE_EPOLL_CREATE1)
+    check_cxx_symbol_exists(eventfd sys/eventfd.h HAVE_EVENTFD)
+    set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS_SAVED})
+endif ()
+
+if (HAVE_SYS_INOTIFY_H AND HAVE_SYS_EPOLL_H AND HAVE_SYS_EVENTFD_H AND
+        HAVE_INOTIFY_INIT1 AND HAVE_EPOLL_CREATE1 AND HAVE_EVENTFD)
+    set(HAVE_INOTIFY_MONITOR 1 CACHE INTERNAL "Linux inotify monitor is available")
     set(LIBFSWATCH_HEADER_FILES
             ${LIBFSWATCH_HEADER_FILES}
             src/libfswatch/c++/inotify_monitor.hpp)
     set(LIB_SOURCE_FILES
             ${LIB_SOURCE_FILES}
             src/libfswatch/c++/inotify_monitor.cpp)
-endif (HAVE_SYS_INOTIFY_H)
+endif ()
 
 check_include_file_cxx(sys/fanotify.h HAVE_SYS_FANOTIFY_H)
 check_include_file_cxx(sys/epoll.h HAVE_SYS_EPOLL_H)

--- a/libfswatch/libfswatch_config.in
+++ b/libfswatch/libfswatch_config.in
@@ -30,6 +30,9 @@
 #cmakedefine HAVE_PORT_H
 #cmakedefine HAVE_STRUCT_STAT_ST_MTIME
 #cmakedefine HAVE_STRUCT_STAT_ST_MTIMESPEC
+#cmakedefine HAVE_INOTIFY_MONITOR
+#cmakedefine HAVE_SYS_EPOLL_H
+#cmakedefine HAVE_SYS_EVENTFD_H
 #cmakedefine HAVE_SYS_EVENT_H
 #cmakedefine HAVE_SYS_FANOTIFY_H
 #cmakedefine HAVE_SYS_INOTIFY_H

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -13,11 +13,18 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
 #include <libfswatch/libfswatch_config.h>
 
 #include "libfswatch/gettext_defs.h"
 #include "inotify_monitor.hpp"
 #include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 #include <limits.h>
@@ -29,7 +36,8 @@
 #include <sstream>
 #include <ctime>
 #include <cmath>
-#include <sys/select.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
 #include "libfswatch_exception.hpp"
 #include "../c/libfswatch_log.h"
 #include "path_utils.hpp"
@@ -40,6 +48,8 @@ namespace fsw
   struct inotify_monitor_impl
   {
     int inotify_monitor_handle = -1;
+    int epoll_handle = -1;
+    int wake_handle = -1;
     std::vector<event> events;
     /*
      * A map of file names by descriptor is kept in sync because the name field
@@ -69,6 +79,75 @@ namespace fsw
   };
 
   static const unsigned int BUFFER_SIZE = (10 * ((sizeof(struct inotify_event)) + NAME_MAX + 1));
+  static const int EPOLL_EVENT_COUNT = 2;
+
+  struct scoped_fd
+  {
+    int fd = -1;
+
+    scoped_fd() = default;
+    explicit scoped_fd(int fd) : fd(fd) {}
+    scoped_fd(const scoped_fd&) = delete;
+    scoped_fd& operator=(const scoped_fd&) = delete;
+
+    ~scoped_fd()
+    {
+      if (fd >= 0) close(fd);
+    }
+
+    int get() const
+    {
+      return fd;
+    }
+
+    int release()
+    {
+      const int released = fd;
+      fd = -1;
+      return released;
+    }
+  };
+
+  static int latency_to_timeout_ms(double latency)
+  {
+    if (latency <= 0) return 0;
+    if (latency >= INT_MAX / 1000.0) return INT_MAX;
+
+    return static_cast<int>(std::ceil(latency * 1000.0));
+  }
+
+  static void add_epoll_interest(int epoll_fd, int fd)
+  {
+    struct epoll_event event {};
+    event.events = EPOLLIN;
+    event.data.fd = fd;
+
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &event) != 0)
+    {
+      fsw_log_perror("epoll_ctl");
+      throw libfsw_exception(_("Cannot initialize inotify."));
+    }
+  }
+
+  static void drain_eventfd(int fd)
+  {
+    for (;;)
+    {
+      uint64_t value = 0;
+      ssize_t read_count = read(fd, &value, sizeof(value));
+
+      if (read_count == static_cast<ssize_t>(sizeof(value))) continue;
+      if (read_count == -1 && errno == EINTR) continue;
+      if (read_count == -1 && errno == EAGAIN) break;
+      if (read_count == -1)
+      {
+        fsw_log_perror("read");
+        break;
+      }
+
+      break;
+    }
+  }
 
   inotify_monitor::inotify_monitor(std::vector<std::string> paths_to_monitor,
                                    FSW_EVENT_CALLBACK *callback,
@@ -76,13 +155,34 @@ namespace fsw
     monitor(paths_to_monitor, callback, context),
     impl(std::make_unique<inotify_monitor_impl>())
   {
-    impl->inotify_monitor_handle = inotify_init();
+    scoped_fd inotify_fd(inotify_init1(IN_CLOEXEC | IN_NONBLOCK));
 
-    if (impl->inotify_monitor_handle == -1)
+    if (inotify_fd.get() == -1)
     {
-      perror("inotify_init");
+      perror("inotify_init1");
       throw libfsw_exception(_("Cannot initialize inotify."));
     }
+
+    scoped_fd wake_fd(eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK));
+    if (wake_fd.get() == -1)
+    {
+      fsw_log_perror("eventfd");
+      throw libfsw_exception(_("Cannot initialize inotify."));
+    }
+
+    scoped_fd epoll_fd(epoll_create1(EPOLL_CLOEXEC));
+    if (epoll_fd.get() == -1)
+    {
+      fsw_log_perror("epoll_create1");
+      throw libfsw_exception(_("Cannot initialize inotify."));
+    }
+
+    add_epoll_interest(epoll_fd.get(), inotify_fd.get());
+    add_epoll_interest(epoll_fd.get(), wake_fd.get());
+
+    impl->inotify_monitor_handle = inotify_fd.release();
+    impl->wake_handle = wake_fd.release();
+    impl->epoll_handle = epoll_fd.release();
   }
 
   inotify_monitor::~inotify_monitor()
@@ -96,9 +196,19 @@ namespace fsw
     }
 
     // close inotify (removes watches)
-    if (impl->inotify_monitor_handle > 0)
+    if (impl->inotify_monitor_handle >= 0)
     {
       close(impl->inotify_monitor_handle);
+    }
+
+    if (impl->epoll_handle >= 0)
+    {
+      close(impl->epoll_handle);
+    }
+
+    if (impl->wake_handle >= 0)
+    {
+      close(impl->wake_handle);
     }
   }
 
@@ -411,11 +521,29 @@ namespace fsw
     impl->paths_to_fire_create.clear();
   }
 
+  void inotify_monitor::on_stop()
+  {
+    if (!impl || impl->wake_handle < 0) return;
+
+    uint64_t value = 1;
+    for (;;)
+    {
+      ssize_t write_count = write(impl->wake_handle, &value, sizeof(value));
+
+      if (write_count == static_cast<ssize_t>(sizeof(value))) break;
+      if (write_count == -1 && errno == EINTR) continue;
+      if (write_count == -1 && errno == EAGAIN) break;
+
+      fsw_log_perror("write");
+      break;
+    }
+  }
+
   void inotify_monitor::run()
   {
-    char buffer[BUFFER_SIZE];
-    double sec;
-    double frac = modf(this->latency, &sec);
+    std::array<char, BUFFER_SIZE> buffer{};
+    std::array<struct epoll_event, EPOLL_EVENT_COUNT> epoll_events{};
+    const int timeout_ms = latency_to_timeout_ms(this->latency);
 
     for(;;)
     {
@@ -427,69 +555,76 @@ namespace fsw
 
       scan_root_paths();
 
-      // If no files can be watched, sleep and repeat the loop.
-      if (!impl->watched_descriptors.size())
-      {
-        sleep(latency);
-        continue;
-      }
-
-      // Use select to timeout on file descriptor read the amount specified by
+      // Use epoll to timeout on file descriptor read the amount specified by
       // the monitor latency.  This way, the monitor has a chance to update its
       // watches with at least the periodicity expected by the user.
-      fd_set set;
-      struct timeval timeout;
-
-      FD_ZERO(&set);
-      FD_SET(impl->inotify_monitor_handle, &set);
-      timeout.tv_sec = sec;
-      timeout.tv_usec = 1000 * 1000 * frac;
-
-      int rv = select(impl->inotify_monitor_handle + 1,
-                      &set,
-                      nullptr,
-                      nullptr,
-                      &timeout);
+      int rv = epoll_wait(impl->epoll_handle,
+                          epoll_events.data(),
+                          epoll_events.size(),
+                          timeout_ms);
 
       if (rv == -1)
       {
-	fsw_log_perror("select");
-	continue;
+        if (errno == EINTR) continue;
+        fsw_log_perror("epoll_wait");
+        continue;
       }
 
-      // In case of read timeout just repeat the loop.
+      // In case of wait timeout just repeat the loop.
       if (rv == 0) continue;
 
-      ssize_t record_num = read(impl->inotify_monitor_handle,
-                                buffer,
-                                BUFFER_SIZE);
+      bool wake_requested = false;
 
+      for (int i = 0; i < rv; ++i)
       {
-        std::ostringstream log;
-        log << _("Number of records: ") << record_num << "\n";
-        FSW_ELOG(log.str().c_str());
-      }
+        if (epoll_events[i].data.fd == impl->wake_handle)
+        {
+          drain_eventfd(impl->wake_handle);
+          wake_requested = true;
+          continue;
+        }
 
-      if (!record_num)
-      {
-        throw libfsw_exception(_("read() on inotify descriptor read 0 records."));
-      }
+        if (epoll_events[i].data.fd != impl->inotify_monitor_handle)
+        {
+          continue;
+        }
 
-      if (record_num == -1)
-      {
-        perror("read()");
-        throw libfsw_exception(_("read() on inotify descriptor returned -1."));
-      }
+        for (;;)
+        {
+          ssize_t record_num = read(impl->inotify_monitor_handle,
+                                    buffer.data(),
+                                    buffer.size());
 
-      time(&impl->curr_time);
+          {
+            std::ostringstream log;
+            log << _("Number of records: ") << record_num << "\n";
+            FSW_ELOG(log.str().c_str());
+          }
 
-      for (char *p = buffer; p < buffer + record_num;)
-      {
-        struct inotify_event const *event = reinterpret_cast<struct inotify_event *> (p);
+          if (!record_num)
+          {
+            throw libfsw_exception(_("read() on inotify descriptor read 0 records."));
+          }
 
-        preprocess_event(event);
+          if (record_num == -1)
+          {
+            if (errno == EAGAIN) break;
+            if (errno == EINTR) continue;
+            perror("read()");
+            throw libfsw_exception(_("read() on inotify descriptor returned -1."));
+          }
 
-        p += (sizeof(struct inotify_event)) + event->len;
+          time(&impl->curr_time);
+
+          for (char *p = buffer.data(); p < buffer.data() + record_num;)
+          {
+            struct inotify_event const *event = reinterpret_cast<struct inotify_event *> (p);
+
+            preprocess_event(event);
+
+            p += (sizeof(struct inotify_event)) + event->len;
+          }
+        }
       }
 
       if (!impl->events.empty())
@@ -506,8 +641,7 @@ namespace fsw
         notify_events(impl->events);
         impl->events.clear();
       }
-
-      sleep(latency);
+      if (wake_requested) break;
     }
   }
 }

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
@@ -71,6 +71,7 @@ namespace fsw
      * @see stop()
      */
     void run() override;
+    void on_stop() override;
 
   private:
     inotify_monitor(const inotify_monitor& orig) = delete;

--- a/libfswatch/src/libfswatch/c++/monitor_factory.cpp
+++ b/libfswatch/src/libfswatch/c++/monitor_factory.cpp
@@ -27,7 +27,7 @@
 #if defined(HAVE_PORT_H)
   #include "fen_monitor.hpp"
 #endif
-#if defined(HAVE_SYS_INOTIFY_H)
+#if defined(HAVE_INOTIFY_MONITOR)
   #include "inotify_monitor.hpp"
 #endif
 #if defined(HAVE_FANOTIFY)
@@ -52,7 +52,7 @@ namespace fsw
     type = fsw_monitor_type::kqueue_monitor_type;
 #elif defined(HAVE_PORT_H)
     type = fsw_monitor_type::fen_monitor_type;
-#elif defined(HAVE_SYS_INOTIFY_H)
+#elif defined(HAVE_INOTIFY_MONITOR)
     type = fsw_monitor_type::inotify_monitor_type;
 #elif defined(HAVE_WINDOWS)
     type = fsw_monitor_type::windows_monitor_type;
@@ -83,7 +83,7 @@ namespace fsw
 #if defined(HAVE_SYS_EVENT_H)
       case kqueue_monitor_type:return new kqueue_monitor(paths, callback, context);
 #endif
-#if defined(HAVE_SYS_INOTIFY_H)
+#if defined(HAVE_INOTIFY_MONITOR)
       case inotify_monitor_type:
         return new inotify_monitor(paths, callback, context);
 #endif
@@ -121,7 +121,7 @@ namespace fsw
 #if defined(HAVE_PORT_H)
     creator_by_string_set[fsw_quote(fen_monitor)] = fsw_monitor_type::fen_monitor_type;
 #endif
-#if defined(HAVE_SYS_INOTIFY_H)
+#if defined(HAVE_INOTIFY_MONITOR)
     creator_by_string_set[fsw_quote(inotify_monitor)] = fsw_monitor_type::inotify_monitor_type;
 #endif
 #if defined(HAVE_FANOTIFY)

--- a/scripts/test/cmake-sanitizers.sh
+++ b/scripts/test/cmake-sanitizers.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+BUILD_DIR=${BUILD_DIR:-build-sanitize}
+JOBS=${JOBS:-2}
+SANITIZERS=${SANITIZERS:-address,undefined}
+SANITIZER_FLAGS="-g -O1 -fsanitize=${SANITIZERS} -fno-omit-frame-pointer"
+CXX=${CXX:-c++}
+export CCACHE_DISABLE=${CCACHE_DISABLE:-1}
+export ASAN_OPTIONS=${ASAN_OPTIONS:-detect_leaks=1:abort_on_error=1}
+export UBSAN_OPTIONS=${UBSAN_OPTIONS:-print_stacktrace=1:halt_on_error=1}
+
+TMPDIR=${TMPDIR:-/tmp}
+CHECK_DIR=$(mktemp -d "${TMPDIR%/}/fswatch-sanitizer-check.XXXXXX")
+trap 'rm -rf "${CHECK_DIR}"' EXIT INT TERM
+
+printf 'int main() { return 0; }\n' > "${CHECK_DIR}/sanitizer-check.cpp"
+if ! "${CXX}" ${SANITIZER_FLAGS} "${CHECK_DIR}/sanitizer-check.cpp" \
+  -o "${CHECK_DIR}/sanitizer-check" >/dev/null 2>"${CHECK_DIR}/sanitizer-check.err"; then
+  echo "sanitizer compiler/link check failed for: ${SANITIZERS}" >&2
+  sed -n '1,120p' "${CHECK_DIR}/sanitizer-check.err" >&2
+  exit 1
+fi
+
+cmake -S . -B "${BUILD_DIR}" \
+  -DBUILD_TESTING=ON \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_FLAGS_DEBUG="${SANITIZER_FLAGS}" \
+  -DCMAKE_CXX_FLAGS_DEBUG="${SANITIZER_FLAGS}" \
+  -DCMAKE_EXE_LINKER_FLAGS_DEBUG="-fsanitize=${SANITIZERS}" \
+  -DCMAKE_SHARED_LINKER_FLAGS_DEBUG="-fsanitize=${SANITIZERS}"
+
+cmake --build "${BUILD_DIR}" -j "${JOBS}"
+ctest --test-dir "${BUILD_DIR}" --output-on-failure

--- a/scripts/test/inotify-stress-soak.sh
+++ b/scripts/test/inotify-stress-soak.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+BUILD_DIR=${BUILD_DIR:-build-inotify-soak}
+ITERATIONS=${ITERATIONS:-50}
+JOBS=${JOBS:-2}
+export CCACHE_DISABLE=${CCACHE_DISABLE:-1}
+
+cmake -S . -B "${BUILD_DIR}" -DBUILD_TESTING=ON
+cmake --build "${BUILD_DIR}" -j "${JOBS}"
+
+i=1
+while [ "${i}" -le "${ITERATIONS}" ]; do
+  printf 'inotify stress soak iteration %s/%s\n' "${i}" "${ITERATIONS}"
+  ctest --test-dir "${BUILD_DIR}" -L inotify --output-on-failure
+  i=$((i + 1))
+done

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,27 +14,47 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+AM_CPPFLAGS = -I$(top_srcdir)/libfswatch/src -I$(top_builddir)
+LDADD = $(top_builddir)/libfswatch/src/libfswatch.la
+
 LOG_COMPILER = $(SHELL)
 AM_TESTS_ENVIRONMENT = \
   FSWATCH='$(abs_top_builddir)/fswatch/src/fswatch'; export FSWATCH; \
   GIT='git'; export GIT;
 
 TESTS =
+EXTRA_DIST =
+check_PROGRAMS =
 
 if USE_INOTIFY
-TESTS += inotify_access_events.sh
-TESTS += inotify_recursive_create.sh
+  check_PROGRAMS += inotify_stop_latency_test
+  check_PROGRAMS += inotify_stop_with_pending_events_test
+
+  inotify_stop_latency_test_SOURCES = src/inotify_stop_latency_test.cpp
+  inotify_stop_with_pending_events_test_SOURCES = src/inotify_stop_with_pending_events_test.cpp
+
+  TESTS += inotify_basic_events.sh
+  TESTS += inotify_access_events.sh
+  TESTS += inotify_missing_root_rescan.sh
+  TESTS += inotify_watched_file_recreate.sh
+  TESTS += inotify_burst_create.sh
+  TESTS += inotify_recursive_create.sh
+  TESTS += inotify_stop_latency_test
+  TESTS += inotify_stop_with_pending_events_test
 endif
 
 if USE_FANOTIFY
-TESTS += fanotify_basic.sh
-TESTS += fanotify_access_events.sh
-TESTS += fanotify_unlimited_properties.sh
+  TESTS += fanotify_basic.sh
+  TESTS += fanotify_access_events.sh
+  TESTS += fanotify_unlimited_properties.sh
 endif
 
-EXTRA_DIST = \
-  inotify_access_events.sh \
-  inotify_recursive_create.sh \
-  fanotify_basic.sh \
-  fanotify_access_events.sh \
-  fanotify_unlimited_properties.sh
+EXTRA_DIST += inotify_basic_events.sh
+EXTRA_DIST += inotify_access_events.sh
+EXTRA_DIST += inotify_missing_root_rescan.sh
+EXTRA_DIST += inotify_watched_file_recreate.sh
+EXTRA_DIST += inotify_burst_create.sh
+EXTRA_DIST += inotify_recursive_create.sh
+EXTRA_DIST += fanotify_basic.sh
+EXTRA_DIST += fanotify_access_events.sh
+EXTRA_DIST += fanotify_unlimited_properties.sh

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,18 +29,23 @@ check_PROGRAMS =
 if USE_INOTIFY
   check_PROGRAMS += inotify_stop_latency_test
   check_PROGRAMS += inotify_stop_with_pending_events_test
+  check_PROGRAMS += inotify_stop_with_ready_events_test
 
   inotify_stop_latency_test_SOURCES = src/inotify_stop_latency_test.cpp
   inotify_stop_with_pending_events_test_SOURCES = src/inotify_stop_with_pending_events_test.cpp
+  inotify_stop_with_ready_events_test_SOURCES = src/inotify_stop_with_ready_events_test.cpp
 
   TESTS += inotify_basic_events.sh
   TESTS += inotify_access_events.sh
   TESTS += inotify_missing_root_rescan.sh
   TESTS += inotify_watched_file_recreate.sh
+  TESTS += inotify_watched_directory_replace.sh
   TESTS += inotify_burst_create.sh
+  TESTS += inotify_queue_drain.sh
   TESTS += inotify_recursive_create.sh
   TESTS += inotify_stop_latency_test
   TESTS += inotify_stop_with_pending_events_test
+  TESTS += inotify_stop_with_ready_events_test
 endif
 
 if USE_FANOTIFY
@@ -53,7 +58,9 @@ EXTRA_DIST += inotify_basic_events.sh
 EXTRA_DIST += inotify_access_events.sh
 EXTRA_DIST += inotify_missing_root_rescan.sh
 EXTRA_DIST += inotify_watched_file_recreate.sh
+EXTRA_DIST += inotify_watched_directory_replace.sh
 EXTRA_DIST += inotify_burst_create.sh
+EXTRA_DIST += inotify_queue_drain.sh
 EXTRA_DIST += inotify_recursive_create.sh
 EXTRA_DIST += fanotify_basic.sh
 EXTRA_DIST += fanotify_access_events.sh

--- a/test/inotify_access_events.sh
+++ b/test/inotify_access_events.sh
@@ -16,10 +16,14 @@
 
 set -eu
 
-if [ "$#" -eq 1 ]; then
-  FSWATCH=$1
-elif [ -z "${FSWATCH:-}" ]; then
-  echo "usage: $0 FSWATCH" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
   exit 2
 fi
 

--- a/test/inotify_basic_events.sh
+++ b/test/inotify_basic_events.sh
@@ -16,12 +16,16 @@
 
 set -eu
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: $0 FSWATCH" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
   exit 2
 fi
 
-FSWATCH=$1
+FSWATCH=${1:-${FSWATCH:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
 
 TMPDIR=${TMPDIR:-/tmp}
 WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-basic.XXXXXX")

--- a/test/inotify_basic_events.sh
+++ b/test/inotify_basic_events.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 FSWATCH" >&2
+  exit 2
+fi
+
+FSWATCH=$1
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-basic.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+TESTDIR="${WORKDIR}/watched"
+mkdir "${TESTDIR}"
+
+"${FSWATCH}" -m inotify_monitor -r --format '%p %f' "${TESTDIR}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+CREATE_FILE="${TESTDIR}/created.txt"
+MOVE_SOURCE="${TESTDIR}/move-source.txt"
+MOVE_TARGET="${TESTDIR}/move-target.txt"
+DELETE_FILE="${TESTDIR}/delete-me.txt"
+
+echo created > "${CREATE_FILE}"
+echo update >> "${CREATE_FILE}"
+echo move > "${MOVE_SOURCE}"
+mv "${MOVE_SOURCE}" "${MOVE_TARGET}"
+echo delete > "${DELETE_FILE}"
+rm "${DELETE_FILE}"
+
+assert_event() {
+  pattern=$1
+  description=$2
+  found=
+  attempt=0
+
+  while [ "${attempt}" -lt 8 ]; do
+    if grep -Eq "${pattern}" "${WORKDIR}/out.log"; then
+      found=1
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  if [ -z "${found}" ]; then
+    echo "missing inotify event: ${description}" >&2
+    echo "--- fswatch output ---" >&2
+    sed -n '1,160p' "${WORKDIR}/out.log" >&2
+    echo "--- fswatch stderr ---" >&2
+    sed -n '1,80p' "${WORKDIR}/err.log" >&2
+    exit 1
+  fi
+}
+
+assert_event 'created\.txt .*Created' 'file creation'
+assert_event 'created\.txt .*(Updated|CloseWrite)' 'file update'
+assert_event '/watched .*MovedFrom' 'rename source'
+assert_event '/watched .*MovedTo' 'rename target'
+assert_event 'delete-me\.txt .*Removed' 'file deletion'

--- a/test/inotify_burst_create.sh
+++ b/test/inotify_burst_create.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2014-2026 Enrico M. Crisostomo
+# Copyright (c) 2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -16,24 +16,19 @@
 
 set -eu
 
-if [ "$#" -gt 2 ]; then
-  echo "usage: $0 [FSWATCH] [GIT]" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
   exit 2
 fi
 
 FSWATCH=${1:-${FSWATCH:-}}
-GIT=${2:-${GIT:-git}}
 if [ -z "${FSWATCH}" ]; then
   echo "FSWATCH is required" >&2
   exit 2
 fi
-if ! command -v "${GIT}" >/dev/null 2>&1; then
-  echo "git is unavailable" >&2
-  exit 77
-fi
 
 TMPDIR=${TMPDIR:-/tmp}
-WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-recursive.XXXXXX")
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-burst.XXXXXX")
 PID=
 
 cleanup() {
@@ -47,22 +42,28 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-cd "${WORKDIR}"
-"${GIT}" init -q
+TESTDIR="${WORKDIR}/watched"
+mkdir "${TESTDIR}"
 
-"${FSWATCH}" -m inotify_monitor -rx --event Created .git > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+"${FSWATCH}" -m inotify_monitor -r --format '%p %f' --event Created "${TESTDIR}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
 PID=$!
 
 sleep 1
 
-echo one > 1.txt
-"${GIT}" add 1.txt
+expected=250
+i=0
+while [ "${i}" -lt "${expected}" ]; do
+  printf '%s\n' "${i}" > "${TESTDIR}/burst-${i}.txt"
+  i=$((i + 1))
+done
 
 found=
 attempt=0
 
-while [ "${attempt}" -lt 8 ]; do
-  if grep -Eq '/\.git/objects/[^/]+/[^/]+ Created$' "${WORKDIR}/out.log"; then
+while [ "${attempt}" -lt 10 ]; do
+  count=$(grep -Ec '/burst-[0-9]+\.txt Created$' "${WORKDIR}/out.log" || true)
+  if [ "${count}" -ge "${expected}" ]; then
     found=1
     break
   fi
@@ -72,12 +73,10 @@ while [ "${attempt}" -lt 8 ]; do
 done
 
 if [ -z "${found}" ]; then
-  echo "missing synthetic create event for git object file" >&2
+  echo "missing burst create events: expected ${expected}, found ${count:-0}" >&2
   echo "--- fswatch output ---" >&2
-  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  sed -n '1,220p' "${WORKDIR}/out.log" >&2
   echo "--- fswatch stderr ---" >&2
-  sed -n '1,80p' "${WORKDIR}/err.log" >&2
-  echo "--- git object files ---" >&2
-  find "${WORKDIR}/.git/objects" -type f -print >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
   exit 1
 fi

--- a/test/inotify_missing_root_rescan.sh
+++ b/test/inotify_missing_root_rescan.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 FSWATCH" >&2
+  exit 2
+fi
+
+FSWATCH=$1
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-missing-root.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+WATCHED="${WORKDIR}/watched"
+
+"${FSWATCH}" -m inotify_monitor -1 -x --event Created -l 1 "${WATCHED}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 2
+mkdir "${WATCHED}"
+sleep 2
+echo content > "${WATCHED}/created-after-root.txt"
+
+found=
+attempt=0
+
+while [ "${attempt}" -lt 8 ]; do
+  if grep -Eq 'created-after-root\.txt .*Created' "${WORKDIR}/out.log"; then
+    found=1
+    break
+  fi
+
+  if ! kill -0 "${PID}" 2>/dev/null; then
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "missing event after initially absent root was created" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/inotify_missing_root_rescan.sh
+++ b/test/inotify_missing_root_rescan.sh
@@ -16,12 +16,16 @@
 
 set -eu
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: $0 FSWATCH" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
   exit 2
 fi
 
-FSWATCH=$1
+FSWATCH=${1:-${FSWATCH:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
 
 TMPDIR=${TMPDIR:-/tmp}
 WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-missing-root.XXXXXX")

--- a/test/inotify_queue_drain.sh
+++ b/test/inotify_queue_drain.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-queue-drain.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+TESTDIR="${WORKDIR}/watched"
+mkdir "${TESTDIR}"
+
+"${FSWATCH}" -m inotify_monitor -r --format '%p %f' --event Created "${TESTDIR}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+expected=1200
+i=0
+while [ "${i}" -lt "${expected}" ]; do
+  printf '%s\n' "${i}" > "${TESTDIR}/drain-${i}.txt"
+  i=$((i + 1))
+done
+
+found=
+attempt=0
+
+while [ "${attempt}" -lt 15 ]; do
+  count=$(
+    sed -n 's|.*/drain-\([0-9][0-9]*\)\.txt Created$|\1|p' "${WORKDIR}/out.log" |
+      sort -n -u |
+      wc -l |
+      tr -d ' '
+  )
+
+  if [ "${count}" -ge "${expected}" ]; then
+    found=1
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "missing queue-drain create events: expected ${expected}, found ${count:-0}" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,260p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/inotify_watched_directory_replace.sh
+++ b/test/inotify_watched_directory_replace.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-dir-replace.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+WATCHED="${WORKDIR}/watched-dir"
+MOVED="${WORKDIR}/moved-dir"
+mkdir "${WATCHED}"
+
+"${FSWATCH}" -m inotify_monitor -r -l 1 --format '%p %f' \
+  --event Created --event CloseWrite "${WATCHED}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+wait_for_child_event() {
+  file_name=$1
+  found=
+  attempt=0
+
+  while [ "${attempt}" -lt 8 ]; do
+    if grep -Eq "/${file_name} .*(Created|CloseWrite)" "${WORKDIR}/out.log"; then
+      found=1
+      break
+    fi
+
+    printf '%s\n' "${attempt}" >> "${WATCHED}/${file_name}"
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  if [ -z "${found}" ]; then
+    echo "missing event after watched directory replacement for ${file_name}" >&2
+    echo "--- fswatch output ---" >&2
+    sed -n '1,180p' "${WORKDIR}/out.log" >&2
+    echo "--- fswatch stderr ---" >&2
+    sed -n '1,120p' "${WORKDIR}/err.log" >&2
+    exit 1
+  fi
+}
+
+mv "${WATCHED}" "${MOVED}"
+sleep 1
+mkdir "${WATCHED}"
+sleep 1
+wait_for_child_event "after-move.txt"
+
+rm -rf "${WATCHED}"
+sleep 1
+mkdir "${WATCHED}"
+sleep 1
+wait_for_child_event "after-delete.txt"

--- a/test/inotify_watched_file_recreate.sh
+++ b/test/inotify_watched_file_recreate.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2014-2026 Enrico M. Crisostomo
+# Copyright (c) 2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -16,24 +16,19 @@
 
 set -eu
 
-if [ "$#" -gt 2 ]; then
-  echo "usage: $0 [FSWATCH] [GIT]" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
   exit 2
 fi
 
 FSWATCH=${1:-${FSWATCH:-}}
-GIT=${2:-${GIT:-git}}
 if [ -z "${FSWATCH}" ]; then
   echo "FSWATCH is required" >&2
   exit 2
 fi
-if ! command -v "${GIT}" >/dev/null 2>&1; then
-  echo "git is unavailable" >&2
-  exit 77
-fi
 
 TMPDIR=${TMPDIR:-/tmp}
-WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-recursive.XXXXXX")
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-inotify-recreate.XXXXXX")
 PID=
 
 cleanup() {
@@ -47,23 +42,32 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-cd "${WORKDIR}"
-"${GIT}" init -q
+WATCHED="${WORKDIR}/watched-file.txt"
+echo initial > "${WATCHED}"
 
-"${FSWATCH}" -m inotify_monitor -rx --event Created .git > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+"${FSWATCH}" -m inotify_monitor -1 -x -l 1 \
+  --event Updated --event CloseWrite "${WATCHED}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
 PID=$!
 
 sleep 1
 
-echo one > 1.txt
-"${GIT}" add 1.txt
+rm "${WATCHED}"
+sleep 1
+echo recreated > "${WATCHED}"
 
 found=
 attempt=0
 
 while [ "${attempt}" -lt 8 ]; do
-  if grep -Eq '/\.git/objects/[^/]+/[^/]+ Created$' "${WORKDIR}/out.log"; then
+  echo update >> "${WATCHED}"
+
+  if grep -Eq 'watched-file\.txt .*(Updated|CloseWrite)' "${WORKDIR}/out.log"; then
     found=1
+    break
+  fi
+
+  if ! kill -0 "${PID}" 2>/dev/null; then
     break
   fi
 
@@ -72,12 +76,10 @@ while [ "${attempt}" -lt 8 ]; do
 done
 
 if [ -z "${found}" ]; then
-  echo "missing synthetic create event for git object file" >&2
+  echo "missing event after watched file was deleted and recreated" >&2
   echo "--- fswatch output ---" >&2
   sed -n '1,160p' "${WORKDIR}/out.log" >&2
   echo "--- fswatch stderr ---" >&2
-  sed -n '1,80p' "${WORKDIR}/err.log" >&2
-  echo "--- git object files ---" >&2
-  find "${WORKDIR}/.git/objects" -type f -print >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
   exit 1
 fi

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -26,54 +26,82 @@ if (BUILD_TESTING)
     find_program(SH_EXECUTABLE sh)
     find_program(GIT_EXECUTABLE git)
 
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SH_EXECUTABLE)
-        add_test(NAME inotify_access_events
-                COMMAND ${SH_EXECUTABLE}
-                        ${PROJECT_SOURCE_DIR}/test/inotify_access_events.sh
-                        $<TARGET_FILE:fswatch>)
-        set_tests_properties(inotify_access_events PROPERTIES
+    if (HAVE_INOTIFY_MONITOR)
+        add_executable(inotify_stop_latency_test inotify_stop_latency_test.cpp)
+        target_include_directories(inotify_stop_latency_test PRIVATE ../.. .)
+        target_include_directories(inotify_stop_latency_test BEFORE PRIVATE ${PROJECT_BINARY_DIR})
+        target_link_libraries(inotify_stop_latency_test PUBLIC libfswatch)
+        add_test(NAME inotify_stop_latency_test COMMAND inotify_stop_latency_test)
+        set_tests_properties(inotify_stop_latency_test PROPERTIES
                 LABELS "integration;inotify"
-                TIMEOUT 15)
+                TIMEOUT 5)
 
-        if (GIT_EXECUTABLE)
-            add_test(NAME inotify_recursive_create
+        if (SH_EXECUTABLE)
+            add_test(NAME inotify_basic_events
                     COMMAND ${SH_EXECUTABLE}
-                            ${PROJECT_SOURCE_DIR}/test/inotify_recursive_create.sh
-                            $<TARGET_FILE:fswatch>
-                            ${GIT_EXECUTABLE})
-            set_tests_properties(inotify_recursive_create PROPERTIES
+                            ${PROJECT_SOURCE_DIR}/test/inotify_basic_events.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_basic_events PROPERTIES
                     LABELS "integration;inotify"
                     TIMEOUT 15)
+
+            add_test(NAME inotify_access_events
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_access_events.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_access_events PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 15)
+
+            add_test(NAME inotify_missing_root_rescan
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_missing_root_rescan.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_missing_root_rescan PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 20)
+
+            if (GIT_EXECUTABLE)
+                add_test(NAME inotify_recursive_create
+                        COMMAND ${SH_EXECUTABLE}
+                                ${PROJECT_SOURCE_DIR}/test/inotify_recursive_create.sh
+                                $<TARGET_FILE:fswatch>
+                                ${GIT_EXECUTABLE})
+                set_tests_properties(inotify_recursive_create PROPERTIES
+                        LABELS "integration;inotify"
+                        TIMEOUT 15)
+            endif ()
         endif ()
 
-        if (HAVE_FANOTIFY)
-            add_test(NAME fanotify_basic
-                    COMMAND ${SH_EXECUTABLE}
-                            ${PROJECT_SOURCE_DIR}/test/fanotify_basic.sh
-                            $<TARGET_FILE:fswatch>)
-            set_tests_properties(fanotify_basic PROPERTIES
-                    LABELS "integration;fanotify"
-                    SKIP_RETURN_CODE 77
-                    TIMEOUT 20)
+    endif ()
 
-            add_test(NAME fanotify_access_events
-                    COMMAND ${SH_EXECUTABLE}
-                            ${PROJECT_SOURCE_DIR}/test/fanotify_access_events.sh
-                            $<TARGET_FILE:fswatch>)
-            set_tests_properties(fanotify_access_events PROPERTIES
-                    LABELS "integration;fanotify"
-                    SKIP_RETURN_CODE 77
-                    TIMEOUT 20)
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SH_EXECUTABLE AND HAVE_FANOTIFY)
+        add_test(NAME fanotify_basic
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/fanotify_basic.sh
+                        $<TARGET_FILE:fswatch>)
+        set_tests_properties(fanotify_basic PROPERTIES
+                LABELS "integration;fanotify"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
 
-            add_test(NAME fanotify_unlimited_properties
-                    COMMAND ${SH_EXECUTABLE}
-                            ${PROJECT_SOURCE_DIR}/test/fanotify_unlimited_properties.sh
-                            $<TARGET_FILE:fswatch>)
-            set_tests_properties(fanotify_unlimited_properties PROPERTIES
-                    LABELS "integration;fanotify"
-                    SKIP_RETURN_CODE 77
-                    TIMEOUT 20)
-        endif ()
+        add_test(NAME fanotify_access_events
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/fanotify_access_events.sh
+                        $<TARGET_FILE:fswatch>)
+        set_tests_properties(fanotify_access_events PROPERTIES
+                LABELS "integration;fanotify"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
+
+        add_test(NAME fanotify_unlimited_properties
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/fanotify_unlimited_properties.sh
+                        $<TARGET_FILE:fswatch>)
+        set_tests_properties(fanotify_unlimited_properties PROPERTIES
+                LABELS "integration;fanotify"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
     endif ()
 
     if (APPLE)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -36,6 +36,15 @@ if (BUILD_TESTING)
                 LABELS "integration;inotify"
                 TIMEOUT 5)
 
+        add_executable(inotify_stop_with_pending_events_test inotify_stop_with_pending_events_test.cpp)
+        target_include_directories(inotify_stop_with_pending_events_test PRIVATE ../.. .)
+        target_include_directories(inotify_stop_with_pending_events_test BEFORE PRIVATE ${PROJECT_BINARY_DIR})
+        target_link_libraries(inotify_stop_with_pending_events_test PUBLIC libfswatch)
+        add_test(NAME inotify_stop_with_pending_events_test COMMAND inotify_stop_with_pending_events_test)
+        set_tests_properties(inotify_stop_with_pending_events_test PROPERTIES
+                LABELS "integration;inotify"
+                TIMEOUT 5)
+
         if (SH_EXECUTABLE)
             add_test(NAME inotify_basic_events
                     COMMAND ${SH_EXECUTABLE}
@@ -58,6 +67,22 @@ if (BUILD_TESTING)
                             ${PROJECT_SOURCE_DIR}/test/inotify_missing_root_rescan.sh
                             $<TARGET_FILE:fswatch>)
             set_tests_properties(inotify_missing_root_rescan PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 20)
+
+            add_test(NAME inotify_watched_file_recreate
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_watched_file_recreate.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_watched_file_recreate PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 20)
+
+            add_test(NAME inotify_burst_create
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_burst_create.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_burst_create PROPERTIES
                     LABELS "integration;inotify"
                     TIMEOUT 20)
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -45,6 +45,15 @@ if (BUILD_TESTING)
                 LABELS "integration;inotify"
                 TIMEOUT 5)
 
+        add_executable(inotify_stop_with_ready_events_test inotify_stop_with_ready_events_test.cpp)
+        target_include_directories(inotify_stop_with_ready_events_test PRIVATE ../.. .)
+        target_include_directories(inotify_stop_with_ready_events_test BEFORE PRIVATE ${PROJECT_BINARY_DIR})
+        target_link_libraries(inotify_stop_with_ready_events_test PUBLIC libfswatch)
+        add_test(NAME inotify_stop_with_ready_events_test COMMAND inotify_stop_with_ready_events_test)
+        set_tests_properties(inotify_stop_with_ready_events_test PROPERTIES
+                LABELS "integration;inotify"
+                TIMEOUT 5)
+
         if (SH_EXECUTABLE)
             add_test(NAME inotify_basic_events
                     COMMAND ${SH_EXECUTABLE}
@@ -78,6 +87,14 @@ if (BUILD_TESTING)
                     LABELS "integration;inotify"
                     TIMEOUT 20)
 
+            add_test(NAME inotify_watched_directory_replace
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_watched_directory_replace.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_watched_directory_replace PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 25)
+
             add_test(NAME inotify_burst_create
                     COMMAND ${SH_EXECUTABLE}
                             ${PROJECT_SOURCE_DIR}/test/inotify_burst_create.sh
@@ -85,6 +102,14 @@ if (BUILD_TESTING)
             set_tests_properties(inotify_burst_create PROPERTIES
                     LABELS "integration;inotify"
                     TIMEOUT 20)
+
+            add_test(NAME inotify_queue_drain
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/inotify_queue_drain.sh
+                            $<TARGET_FILE:fswatch>)
+            set_tests_properties(inotify_queue_drain PROPERTIES
+                    LABELS "integration;inotify"
+                    TIMEOUT 25)
 
             if (GIT_EXECUTABLE)
                 add_test(NAME inotify_recursive_create

--- a/test/src/inotify_stop_latency_test.cpp
+++ b/test/src/inotify_stop_latency_test.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <future>
+#include <iostream>
+#include <libfswatch/c/libfswatch.h>
+#include <string>
+#include <thread>
+
+namespace
+{
+  void callback(fsw_cevent const *const, const unsigned int, void *)
+  {
+  }
+
+  bool expect_ok(FSW_STATUS status, const char *message)
+  {
+    if (status == FSW_OK) return true;
+
+    std::cerr << message << ": " << fsw_last_error() << "\n";
+    return false;
+  }
+}
+
+int main()
+{
+  namespace fs = std::filesystem;
+  using namespace std::chrono_literals;
+
+  if (!expect_ok(fsw_init_library(), "fsw_init_library failed")) return 1;
+
+  const fs::path test_dir =
+    fs::temp_directory_path() /
+    ("fswatch-inotify-stop-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  fs::create_directory(test_dir);
+
+  FSW_HANDLE handle = fsw_init_session(inotify_monitor_type);
+  if (!handle)
+  {
+    std::cerr << "fsw_init_session failed\n";
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  bool ok =
+    expect_ok(fsw_add_path(handle, test_dir.string().c_str()), "fsw_add_path failed") &&
+    expect_ok(fsw_set_callback(handle, callback, nullptr), "fsw_set_callback failed") &&
+    expect_ok(fsw_set_latency(handle, 30.0), "fsw_set_latency failed");
+
+  if (!ok)
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  auto monitor_status = std::async(std::launch::async, [handle] {
+    return fsw_start_monitor(handle);
+  });
+
+  std::this_thread::sleep_for(500ms);
+
+  const auto stop_started = std::chrono::steady_clock::now();
+  if (!expect_ok(fsw_stop_monitor(handle), "fsw_stop_monitor failed"))
+  {
+    std::quick_exit(1);
+  }
+
+  if (monitor_status.wait_for(2s) != std::future_status::ready)
+  {
+    std::cerr << "inotify monitor did not stop promptly with long latency\n";
+    std::quick_exit(2);
+  }
+
+  if (!expect_ok(monitor_status.get(), "fsw_start_monitor failed"))
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  const auto stop_elapsed = std::chrono::steady_clock::now() - stop_started;
+  if (stop_elapsed > 2s)
+  {
+    std::cerr << "inotify monitor stop took too long\n";
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  if (!expect_ok(fsw_destroy_session(handle), "fsw_destroy_session failed"))
+  {
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  fs::remove_all(test_dir);
+  return 0;
+}

--- a/test/src/inotify_stop_with_pending_events_test.cpp
+++ b/test/src/inotify_stop_with_pending_events_test.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <libfswatch/c/libfswatch.h>
+#include <string>
+#include <thread>
+
+namespace
+{
+  void callback(fsw_cevent const *const, const unsigned int, void *)
+  {
+  }
+
+  bool expect_ok(FSW_STATUS status, const char *message)
+  {
+    if (status == FSW_OK) return true;
+
+    std::cerr << message << ": " << fsw_last_error() << "\n";
+    return false;
+  }
+}
+
+int main()
+{
+  namespace fs = std::filesystem;
+  using namespace std::chrono_literals;
+
+  if (!expect_ok(fsw_init_library(), "fsw_init_library failed")) return 1;
+
+  const fs::path test_dir =
+    fs::temp_directory_path() /
+    ("fswatch-inotify-stop-pending-" +
+     std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  fs::create_directory(test_dir);
+
+  FSW_HANDLE handle = fsw_init_session(inotify_monitor_type);
+  if (!handle)
+  {
+    std::cerr << "fsw_init_session failed\n";
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  bool ok =
+    expect_ok(fsw_add_path(handle, test_dir.string().c_str()), "fsw_add_path failed") &&
+    expect_ok(fsw_set_callback(handle, callback, nullptr), "fsw_set_callback failed") &&
+    expect_ok(fsw_set_latency(handle, 30.0), "fsw_set_latency failed");
+
+  if (!ok)
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  auto monitor_status = std::async(std::launch::async, [handle] {
+    return fsw_start_monitor(handle);
+  });
+
+  std::this_thread::sleep_for(500ms);
+
+  for (int i = 0; i < 200; ++i)
+  {
+    std::ofstream file(test_dir / ("file-" + std::to_string(i) + ".txt"));
+    file << i << '\n';
+  }
+
+  const auto stop_started = std::chrono::steady_clock::now();
+  if (!expect_ok(fsw_stop_monitor(handle), "fsw_stop_monitor failed"))
+  {
+    std::quick_exit(1);
+  }
+
+  if (monitor_status.wait_for(2s) != std::future_status::ready)
+  {
+    std::cerr << "inotify monitor did not stop promptly with pending events\n";
+    std::quick_exit(2);
+  }
+
+  if (!expect_ok(monitor_status.get(), "fsw_start_monitor failed"))
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  const auto stop_elapsed = std::chrono::steady_clock::now() - stop_started;
+  if (stop_elapsed > 2s)
+  {
+    std::cerr << "inotify monitor stop took too long with pending events\n";
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  if (!expect_ok(fsw_destroy_session(handle), "fsw_destroy_session failed"))
+  {
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  fs::remove_all(test_dir);
+  return 0;
+}

--- a/test/src/inotify_stop_with_ready_events_test.cpp
+++ b/test/src/inotify_stop_with_ready_events_test.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <libfswatch/c/libfswatch.h>
+#include <string>
+#include <thread>
+
+namespace
+{
+  struct callback_context
+  {
+    std::atomic<unsigned int> event_count{0};
+  };
+
+  void callback(fsw_cevent const *const, const unsigned int event_num, void *data)
+  {
+    auto *context = static_cast<callback_context *>(data);
+    context->event_count.fetch_add(event_num, std::memory_order_relaxed);
+  }
+
+  bool expect_ok(FSW_STATUS status, const char *message)
+  {
+    if (status == FSW_OK) return true;
+
+    std::cerr << message << ": " << fsw_last_error() << "\n";
+    return false;
+  }
+}
+
+int main()
+{
+  namespace fs = std::filesystem;
+  using namespace std::chrono_literals;
+
+  if (!expect_ok(fsw_init_library(), "fsw_init_library failed")) return 1;
+
+  const fs::path test_dir =
+    fs::temp_directory_path() /
+    ("fswatch-inotify-stop-ready-" +
+     std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  fs::create_directory(test_dir);
+
+  FSW_HANDLE handle = fsw_init_session(inotify_monitor_type);
+  if (!handle)
+  {
+    std::cerr << "fsw_init_session failed\n";
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  callback_context context;
+  bool ok =
+    expect_ok(fsw_add_path(handle, test_dir.string().c_str()), "fsw_add_path failed") &&
+    expect_ok(fsw_set_callback(handle, callback, &context), "fsw_set_callback failed") &&
+    expect_ok(fsw_set_latency(handle, 30.0), "fsw_set_latency failed");
+
+  if (!ok)
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  auto monitor_status = std::async(std::launch::async, [handle] {
+    return fsw_start_monitor(handle);
+  });
+
+  std::this_thread::sleep_for(500ms);
+
+  for (int i = 0; i < 200; ++i)
+  {
+    std::ofstream file(test_dir / ("ready-" + std::to_string(i) + ".txt"));
+    file << i << '\n';
+  }
+
+  const auto stop_started = std::chrono::steady_clock::now();
+  if (!expect_ok(fsw_stop_monitor(handle), "fsw_stop_monitor failed"))
+  {
+    std::quick_exit(1);
+  }
+
+  if (monitor_status.wait_for(2s) != std::future_status::ready)
+  {
+    std::cerr << "inotify monitor did not stop promptly with ready events\n";
+    std::quick_exit(2);
+  }
+
+  if (!expect_ok(monitor_status.get(), "fsw_start_monitor failed"))
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  if (context.event_count.load(std::memory_order_relaxed) == 0)
+  {
+    std::cerr << "inotify monitor dropped events that were ready before stop\n";
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  const auto stop_elapsed = std::chrono::steady_clock::now() - stop_started;
+  if (stop_elapsed > 2s)
+  {
+    std::cerr << "inotify monitor stop took too long with ready events\n";
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  if (!expect_ok(fsw_destroy_session(handle), "fsw_destroy_session failed"))
+  {
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  fs::remove_all(test_dir);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Refactor the inotify monitor wait loop to use `epoll` with an `eventfd` wakeup path so `fsw_stop_monitor()` can interrupt the monitor promptly.
- Add Autotools and CMake inotify integration coverage for idle stop, stop with pending/ready events, watched file and directory replacement, recursive creates, burst creates, and queue draining.
- Add manual verification scripts for sanitizer runs and longer inotify stress soaks.

## Validation

- `CCACHE_DISABLE=1 make -j2 check` passed, 11/11 inotify tests.
- `ctest --test-dir build-codex --output-on-failure` passed, 11/11 inotify tests.
- `CCACHE_DISABLE=1 make -j2 distcheck` passed, including packaged inotify tests.
- `ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 scripts/test/cmake-sanitizers.sh` passed locally under this tool environment; full leak sanitizer was reported green by the host run.
- `JOBS=8 ITERATIONS=100 scripts/test/inotify-stress-soak.sh` was reported green by the host run.

Fixes #367