### PR TITLE
Bump v. 1.20.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(fswatch VERSION 1.20.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-develop")
+set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 NEWS
 ****
 
-New in 1.20.0-develop:
+New in 1.20.0:
 
   * Issue 365: Add an opt-in Linux fanotify monitor with process attribution
     support and custom output directives for process ID metadata.

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,7 +1,7 @@
 NEWS
 ****
 
-New in 1.20.0-develop:
+New in 1.20.0:
 
   * Issue 365: Add a Linux fanotify monitor and generic event process
     attribution metadata.

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.20.0-develop])
+m4_define([FSWATCH_VERSION], [1.20.0])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.20.0-develop])
-m4_define([LIBFSWATCH_API_VERSION], [14:0:1])
+m4_define([LIBFSWATCH_VERSION], [1.20.0])
+m4_define([LIBFSWATCH_API_VERSION], [14:0:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-25 18:33+0200\n"
+"POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: English\n"
@@ -329,8 +329,8 @@ msgstr ""
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:182
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:404
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
@@ -338,7 +338,7 @@ msgid "Filesystem error: %s"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:390
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr ""
@@ -412,79 +412,82 @@ msgstr ""
 msgid "Unknown flag: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:130
 msgid "Event stream could not be created."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:142
 msgid "Scheduling stream with run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:148
 msgid "Starting event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:164
 msgid "Starting run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:169
 msgid "Stopping event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
 msgid "Invalidating event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:175
 msgid "Releasing event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:192
 msgid "run loop is null"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:194
 msgid "Stopping run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:227
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:356
 msgid "Creating FSEvent stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:128
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:170
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:177
 msgid "Cannot initialize inotify."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:194
 msgid "Removing: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:129
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:239
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:262
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:354
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:481
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,10 +30,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.0-develop\n"
+"Project-Id-Version: fswatch 1.20.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-25 18:33+0200\n"
-"PO-Revision-Date: 2026-04-25 18:33+0200\n"
+"POT-Creation-Date: 2026-04-28 21:41+0200\n"
+"PO-Revision-Date: 2026-04-28 21:41+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@boldquot\n"
@@ -365,8 +365,8 @@ msgstr "fanotify added: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:182
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:404
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
@@ -374,7 +374,7 @@ msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:390
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Synthetic event: processing directory: %s\n"
@@ -448,79 +448,82 @@ msgstr "Unknown filter type: "
 msgid "Unknown flag: "
 msgstr "Unknown flag: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:130
 msgid "Event stream could not be created."
 msgstr "Event stream could not be created."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:142
 msgid "Scheduling stream with run loop...\n"
 msgstr "Scheduling stream with run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:148
 msgid "Starting event stream...\n"
 msgstr "Starting event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:164
 msgid "Starting run loop...\n"
 msgstr "Starting run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:169
 msgid "Stopping event stream...\n"
 msgstr "Stopping event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
 msgid "Invalidating event stream...\n"
 msgstr "Invalidating event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:175
 msgid "Releasing event stream...\n"
 msgstr "Releasing event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:192
 msgid "run loop is null"
 msgstr "run loop is null"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:194
 msgid "Stopping run loop...\n"
 msgstr "Stopping run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:227
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "The callback info cannot be cast to fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:356
 msgid "Creating FSEvent stream...\n"
 msgstr "Creating FSEvent stream...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:128
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:170
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:177
 msgid "Cannot initialize inotify."
 msgstr "Cannot initialize inotify."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:194
 msgid "Removing: "
 msgstr "Removing: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:129
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:239
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:262
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:354
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:481
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,10 +27,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.0-develop\n"
+"Project-Id-Version: fswatch 1.20.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-25 18:33+0200\n"
-"PO-Revision-Date: 2026-04-25 18:33+0200\n"
+"POT-Creation-Date: 2026-04-28 21:41+0200\n"
+"PO-Revision-Date: 2026-04-28 21:41+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@quot\n"
@@ -362,8 +362,8 @@ msgstr "fanotify added: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:182
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:404
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
@@ -371,7 +371,7 @@ msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:390
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Synthetic event: processing directory: %s\n"
@@ -445,79 +445,82 @@ msgstr "Unknown filter type: "
 msgid "Unknown flag: "
 msgstr "Unknown flag: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:130
 msgid "Event stream could not be created."
 msgstr "Event stream could not be created."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:142
 msgid "Scheduling stream with run loop...\n"
 msgstr "Scheduling stream with run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:148
 msgid "Starting event stream...\n"
 msgstr "Starting event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:164
 msgid "Starting run loop...\n"
 msgstr "Starting run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:169
 msgid "Stopping event stream...\n"
 msgstr "Stopping event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
 msgid "Invalidating event stream...\n"
 msgstr "Invalidating event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:175
 msgid "Releasing event stream...\n"
 msgstr "Releasing event stream...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:192
 msgid "run loop is null"
 msgstr "run loop is null"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:194
 msgid "Stopping run loop...\n"
 msgstr "Stopping run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:227
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "The callback info cannot be cast to fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:356
 msgid "Creating FSEvent stream...\n"
 msgstr "Creating FSEvent stream...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:128
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:170
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:177
 msgid "Cannot initialize inotify."
 msgstr "Cannot initialize inotify."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:194
 msgid "Removing: "
 msgstr "Removing: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:129
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:239
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:262
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:354
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:481
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-25 18:33+0200\n"
+"POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -343,8 +343,8 @@ msgstr "fanotify añadido: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:182
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:404
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
@@ -352,7 +352,7 @@ msgid "Filesystem error: %s"
 msgstr "Error del sistema de ficheros: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:390
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Evento sintético: procesando carpeta: %s\n"
@@ -426,79 +426,82 @@ msgstr "Tipo filtro desconocido: "
 msgid "Unknown flag: "
 msgstr "Flag desconocida: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:130
 msgid "Event stream could not be created."
 msgstr "El flujo de eventos no se puede crear."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:142
 msgid "Scheduling stream with run loop...\n"
 msgstr "Planificando el flujo con el bucle de ejecución...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:148
 msgid "Starting event stream...\n"
 msgstr "Arrancando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:164
 msgid "Starting run loop...\n"
 msgstr "Arrancando el bucle de ejecución...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:169
 msgid "Stopping event stream...\n"
 msgstr "Parando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
 msgid "Invalidating event stream...\n"
 msgstr "Invalidando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:175
 msgid "Releasing event stream...\n"
 msgstr "Liberando el flujo de eventos...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:192
 msgid "run loop is null"
 msgstr "el bucle de ejecución es nulo"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:194
 msgid "Stopping run loop...\n"
 msgstr "Parando el bucle de ejecución...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:227
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "El context de callback no puede convertirse a fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:356
 msgid "Creating FSEvent stream...\n"
 msgstr "Creando el flujo FSEvent...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:128
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:170
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:177
 msgid "Cannot initialize inotify."
 msgstr "inotify no puede ser inicializado."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:194
 msgid "Removing: "
 msgstr "Eliminando: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:129
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:239
 msgid "Added: "
 msgstr "Añadiendo: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:262
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
 msgid "Generic event: "
 msgstr "Evento genérico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:354
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
 msgid "Removed: "
 msgstr "Eliminado: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
 msgid "Number of records: "
 msgstr "Numero de registros: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sobre el descriptor inotify leyó 0 registros."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:481
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sobre le descriptor inotify devolvió -1."
 

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.0-develop\n"
+"Project-Id-Version: fswatch 1.20.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-25 18:33+0200\n"
+"POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -329,8 +329,8 @@ msgstr ""
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:182
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:404
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
@@ -338,7 +338,7 @@ msgid "Filesystem error: %s"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:390
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr ""
@@ -412,79 +412,82 @@ msgstr ""
 msgid "Unknown flag: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:130
 msgid "Event stream could not be created."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:142
 msgid "Scheduling stream with run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:148
 msgid "Starting event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:164
 msgid "Starting run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:169
 msgid "Stopping event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
 msgid "Invalidating event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:175
 msgid "Releasing event stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:192
 msgid "run loop is null"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:194
 msgid "Stopping run loop...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:227
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:356
 msgid "Creating FSEvent stream...\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:128
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:170
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:177
 msgid "Cannot initialize inotify."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:194
 msgid "Removing: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:129
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:239
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:262
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:354
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:481
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-25 18:33+0200\n"
+"POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2018-05-02 17:29+0200\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -318,7 +318,9 @@ msgstr "Non si può inizializzare fanotify."
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:282
 msgid "fanotify TID reporting is not supported by the build headers."
-msgstr "La segnalazione del TID di fanotify non è supportata dagli header di compilazione."
+msgstr ""
+"La segnalazione del TID di fanotify non è supportata dagli header di "
+"compilazione."
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:287
 msgid "Invalid fanotify.process-id value."
@@ -333,7 +335,8 @@ msgstr ""
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:330
 msgid "fanotify pidfd reporting is not supported by the build headers."
 msgstr ""
-"La segnalazione del pidfd di fanotify non è supportata dagli header di compilazione."
+"La segnalazione del pidfd di fanotify non è supportata dagli header di "
+"compilazione."
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:406
 #, c-format
@@ -343,8 +346,8 @@ msgstr "fanotify aggiunto: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:182
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:404
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
 #, c-format
@@ -352,7 +355,7 @@ msgid "Filesystem error: %s"
 msgstr "Errore del file system: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:390
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Evento sintetico: elaborazione directory: %s\n"
@@ -426,79 +429,82 @@ msgstr "Tipo filtro sconosciuto: "
 msgid "Unknown flag: "
 msgstr "Flag sconosciuto: "
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:141
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:130
 msgid "Event stream could not be created."
 msgstr "Il flusso di eventi non può essere creato."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:152
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:142
 msgid "Scheduling stream with run loop...\n"
 msgstr "Pianificazione del flusso con il run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:158
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:148
 msgid "Starting event stream...\n"
 msgstr "Facendo partire il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:174
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:164
 msgid "Starting run loop...\n"
 msgstr "Avvio del run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:179
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:169
 msgid "Stopping event stream...\n"
 msgstr "Fermando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:182
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:172
 msgid "Invalidating event stream...\n"
 msgstr "Invalidando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:185
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:175
 msgid "Releasing event stream...\n"
 msgstr "Liberando il flusso di eventi...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:200
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:192
 msgid "run loop is null"
 msgstr "il run loop è nullo"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:202
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:194
 msgid "Stopping run loop...\n"
 msgstr "Arresto del run loop...\n"
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:235
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:227
 msgid "The callback info cannot be cast to fsevents_monitor."
 msgstr "Il contesto del callback non può essere convertita a fsevents_monitor."
 
-#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:336
+#: libfswatch/src/libfswatch/c++/fsevents_monitor.cpp:356
 msgid "Creating FSEvent stream...\n"
 msgstr "Creando il flusso FSEvent...\n"
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:84
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:128
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:163
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:170
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:177
 msgid "Cannot initialize inotify."
 msgstr "Non si può inizializzare inotify."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:94
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:194
 msgid "Removing: "
 msgstr "Eliminando: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:129
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:239
 msgid "Added: "
 msgstr "Aggiunto: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:262
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
 msgid "Generic event: "
 msgstr "Evento generico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:354
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
 msgid "Removed: "
 msgstr "Eliminato: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:469
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
 msgid "Number of records: "
 msgstr "Numero di registri: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sul descrittore inotify ha trovato 0 registri."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:481
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sul descrittore inotify ha ritornato -1."
 


### PR DESCRIPTION
# What's New in fswatch v. 1.20.0:

`fswatch` v. 1.20.0 introduces the following features and bug fixes:

  * Issue 365: Add an opt-in Linux fanotify monitor with process attribution
    support and custom output directives for process ID metadata.

  * Issue 365: Add opt-in fanotify monitor properties for unlimited event queue
    and mark limits.

  * Issue 365: Fix CMake builds when ignored Autotools configuration headers
    exist in the source tree.

  * Fix CoreFoundation path ownership in the macOS FSEvents monitor.

`libfswatch` v. 1.20.0 introduces the following features and bug fixes:

  * Issue 365: Add a Linux fanotify monitor and generic event process
    attribution metadata.

  * Issue 365: Add opt-in fanotify monitor properties for unlimited event queue
    and mark limits.

  * Issue 365: Add the fsw_cevent_v2 C callback API for correlation and
    process attribution metadata without changing the existing fsw_cevent ABI.

  * Fix CoreFoundation path ownership in the macOS FSEvents monitor.
