### PR TITLE
Document inotify epoll changes in 1.20.0 NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ New in 1.20.0:
   * Issue 365: Fix CMake builds when ignored Autotools configuration headers
     exist in the source tree.
 
+  * PR 368, Issue 367: Refactor the Linux inotify monitor to use an
+    epoll/eventfd wait loop, improving stop responsiveness and event queue
+    draining behavior.
+
   * Fix CoreFoundation path ownership in the macOS FSEvents monitor.
 
 

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -12,6 +12,10 @@ New in 1.20.0:
   * Issue 365: Add the fsw_cevent_v2 C callback API for correlation and
     process attribution metadata without changing the existing fsw_cevent ABI.
 
+  * PR 368, Issue 367: Refactor the Linux inotify monitor to use an
+    epoll/eventfd wait loop.  Building the inotify monitor now requires epoll,
+    eventfd, and inotify_init1 support.
+
   * Fix CoreFoundation path ownership in the macOS FSEvents monitor.
 
 


### PR DESCRIPTION
Correct the 1.20.0 release notes before replacing the existing 1.20.0 release assets.\n\nNEWS audit table for 1.19.1..master:\n\n| Commit | PR/Issue | User-visible change | NEWS action |\n| --- | --- | --- | --- |\n| 0adbb1e | PR 364 | Post-release development version bump. | Omit: release metadata only. |\n| 89ae902 | PR 366, Issue 365 | Add fanotify backend, process attribution, C callback API, CLI formatting, docs, and related build support. | Already covered by the Issue 365 bullets in NEWS and NEWS.libfswatch. |\n| 663a755 | PR 368, Issue 367 | Refactor Linux inotify to use epoll/eventfd, improving stop responsiveness and event draining; changes inotify build prerequisites. | Added to NEWS and NEWS.libfswatch in this PR. |\n| 9d11d22 | none | Update Windows build documentation. | Omit: documentation-only clarification, not a release-note-level behavior/API change. |\n| 83fccdb | none | Fix CoreFoundation path ownership in macOS FSEvents monitor. | Already covered by the FSEvents ownership bullet in NEWS and NEWS.libfswatch. |\n| 2a80c31 | PR 370 | Prepare final 1.20.0 release metadata. | Omit: release metadata only. |\n\nValidation:\n\n- scripts/release/check.zsh --release --require-libfswatch-news 1.20.0\n- scripts/release/notes.zsh --output release-notes.md --require-libfswatch-news 1.20.0\n- scripts/release/check.zsh --release --notes release-notes.md --require-libfswatch-news 1.20.0\n- make -j distcheck\n- scripts/release/check.zsh --release --require-dist --notes release-notes.md --require-libfswatch-news 1.20.0