### PR TITLE
Bump v. 1.20.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.20.0 LANGUAGES C CXX)
+project(fswatch VERSION 1.20.1 LANGUAGES C CXX)
 
 set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 NEWS
 ****
 
+New in 1.20.1:
+
+  * Correct the 1.20.0 release notes to document PR 368, Issue 367: the Linux
+    inotify monitor now uses an epoll/eventfd wait loop, improving stop
+    responsiveness and event queue draining behavior.
+
+
 New in 1.20.0:
 
   * Issue 365: Add an opt-in Linux fanotify monitor with process attribution

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,6 +1,13 @@
 NEWS
 ****
 
+New in 1.20.1:
+
+  * Correct the 1.20.0 release notes to document PR 368, Issue 367: the Linux
+    inotify monitor now uses an epoll/eventfd wait loop, and building it now
+    requires epoll, eventfd, and inotify_init1 support.
+
+
 New in 1.20.0:
 
   * Issue 365: Add a Linux fanotify monitor and generic event process

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.20.0])
+m4_define([FSWATCH_VERSION], [1.20.1])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.20.0])
+m4_define([LIBFSWATCH_VERSION], [1.20.1])
 m4_define([LIBFSWATCH_API_VERSION], [14:0:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,7 +30,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.0\n"
+"Project-Id-Version: fswatch 1.20.1\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2026-04-28 21:41+0200\n"

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,7 +27,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.0\n"
+"Project-Id-Version: fswatch 1.20.1\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2026-04-28 21:41+0200\n"

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.0\n"
+"Project-Id-Version: fswatch 1.20.1\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Prepare fswatch v. 1.20.1 as a corrective patch release after the 1.20.0 NEWS omission.\n\nNEWS audit table for 1.20.0..release/1.20.1:\n\n| Commit | PR/Issue | User-visible change | NEWS action |\n| --- | --- | --- | --- |\n| 2ce618f | PR 371 | Correct 1.20.0 release notes to include the inotify epoll/eventfd changes and build prerequisite change from PR 368 / Issue 367. | Added to NEWS and NEWS.libfswatch in the new 1.20.1 sections. |\n| f55b664 | release/1.20.1 | Bump package version from 1.20.0 to 1.20.1 for the corrective patch release. | Omit: release metadata only. |\n\nLibtool API review:\n\n- Previous LIBFSWATCH_API_VERSION: 14:0:0.\n- Proposed LIBFSWATCH_API_VERSION: 14:0:0.\n- Reason: no libfswatch source or installed API/ABI changes since corrected 1.20.0; this release changes release metadata, NEWS, and gettext catalog version headers only.\n\nValidation:\n\n- ./autogen.sh\n- CC=gcc CXX=g++ ./configure\n- make -C po update-po\n- scripts/release/check.zsh --release --require-libfswatch-news 1.20.1\n- scripts/release/notes.zsh --output release-notes.md --require-libfswatch-news 1.20.1\n- scripts/release/check.zsh --release --notes release-notes.md --require-libfswatch-news 1.20.1\n- make -j distcheck\n- scripts/release/check.zsh --release --require-dist --notes release-notes.md --require-libfswatch-news 1.20.1