### PR TITLE
Bump version to 1.21.0-develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.20.1 LANGUAGES C CXX)
+project(fswatch VERSION 1.21.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "")
+set(VERSION_MODIFIER "-develop")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 NEWS
 ****
 
+New in 1.21.0-develop:
+
+
 New in 1.20.1:
 
   * Correct the 1.20.0 release notes to document PR 368, Issue 367: the Linux

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.20.1])
+m4_define([FSWATCH_VERSION], [1.21.0-develop])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.20.1])
+m4_define([LIBFSWATCH_VERSION], [1.21.0-develop])
 m4_define([LIBFSWATCH_API_VERSION], [14:0:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,7 +30,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.1\n"
+"Project-Id-Version: fswatch 1.21.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2026-04-28 21:41+0200\n"

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,7 +27,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.1\n"
+"Project-Id-Version: fswatch 1.21.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: 2026-04-28 21:41+0200\n"

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.20.1\n"
+"Project-Id-Version: fswatch 1.21.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-04-28 21:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Prepare master for the next development cycle after publishing 1.20.1.\n\nChanges:\n\n- Set fswatch/libfswatch versions to 1.21.0-develop.\n- Set CMake project version to 1.21.0 and VERSION_MODIFIER to -develop.\n- Add the top NEWS section for 1.21.0-develop.\n- Refresh gettext catalog version headers.\n\nValidation:\n\n- ./autogen.sh\n- CC=gcc CXX=g++ ./configure\n- make -C po update-po\n- scripts/release/check.zsh 1.21.0-develop\n\nNote: NEWS.libfswatch intentionally remains at 1.20.1 until a libfswatch user-visible development change lands.