### PR TITLE
Build libfswatch Doxygen docs on release

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies on Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install -y autoconf automake autopoint g++ gettext git libtool make texinfo texlive zsh
+        sudo apt-get install -y autoconf automake autopoint doxygen g++ gettext git libtool make texinfo texlive texlive-font-utils zsh
 
     - name: Check release metadata
       run: scripts/release/check.zsh --release ${{ github.event.release.tag_name }}
@@ -94,5 +94,24 @@ jobs:
         cp ./fswatch/doc/fswatch.pdf "./fswatch-${TAG_NAME}.pdf"
         gh release upload "${TAG_NAME}" \
           "./fswatch-${TAG_NAME}.pdf" \
+          --repo "${GITHUB_REPOSITORY}" \
+          --clobber
+
+    - name: Build libfswatch Doxygen HTML documentation
+      run: make -C libfswatch/doc/doxygen doc-html-doxygen
+
+    - name: Upload Release libfswatch Doxygen HTML documentation
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ github.event.release.tag_name }}
+      run: |
+        test -f ./libfswatch/doc/doxygen/html/index.html
+        DOCS_STAGING="${RUNNER_TEMP}/libfswatch-doxygen-release"
+        rm -rf "${DOCS_STAGING}"
+        mkdir -p "${DOCS_STAGING}/doc/libfswatch/${TAG_NAME}"
+        cp -R ./libfswatch/doc/doxygen/html/. "${DOCS_STAGING}/doc/libfswatch/${TAG_NAME}/"
+        tar -C "${DOCS_STAGING}" -czf "./fswatch-${TAG_NAME}-libfswatch-doxygen-html.tar.gz" "doc/libfswatch/${TAG_NAME}"
+        gh release upload "${TAG_NAME}" \
+          "./fswatch-${TAG_NAME}-libfswatch-doxygen-html.tar.gz" \
           --repo "${GITHUB_REPOSITORY}" \
           --clobber


### PR DESCRIPTION
## Summary

- install Doxygen and TeX font utilities in the release workflow
- build the libfswatch Doxygen HTML documentation with the existing Autotools target
- package the generated HTML under `doc/libfswatch/<tag>/` and attach it to the GitHub release

Closes #374.

## Validation

- `actionlint .github/workflows/release-tarball.yml`
- `./autogen.sh`
- `./configure`
- `make -C libfswatch/doc/doxygen doc-html-doxygen`
- verified the generated archive layout locally starts with `doc/libfswatch/test-tag/`