### PR TITLE
Install libfswatch CMake package config

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ NEWS
 
 New in 1.21.0-develop:
 
+  * Issue 305: Install CMake package configuration files for libfswatch so
+    CMake consumers can use find_package(libfswatch CONFIG).
+
 
 New in 1.20.1:
 

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,6 +1,12 @@
 NEWS
 ****
 
+New in 1.21.0-develop:
+
+  * Issue 305: Install CMake package configuration files and exported targets
+    for libfswatch so CMake consumers can use find_package(libfswatch CONFIG).
+
+
 New in 1.20.1:
 
   * Correct the 1.20.0 release notes to document PR 368, Issue 367: the Linux

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -266,3 +266,19 @@ install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/libfswatchConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/libfswatchConfigVersion.cmake"
     DESTINATION "${LIBFSWATCH_INSTALL_CMAKEDIR}")
+
+if (BUILD_TESTING)
+    add_test(NAME libfswatch_package_consumer
+        COMMAND ${CMAKE_COMMAND}
+            -DTEST_BUILD_DIR=${PROJECT_BINARY_DIR}
+            -DTEST_WORK_DIR=${PROJECT_BINARY_DIR}/test/libfswatch_package_consumer
+            -DTEST_CONFIG=$<CONFIG>
+            -DTEST_GENERATOR=${CMAKE_GENERATOR}
+            -DTEST_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
+            -DTEST_GENERATOR_TOOLSET=${CMAKE_GENERATOR_TOOLSET}
+            -DTEST_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -P ${PROJECT_SOURCE_DIR}/test/cmake/libfswatch_package_consumer.cmake)
+    set_tests_properties(libfswatch_package_consumer PROPERTIES
+        LABELS "package;cmake"
+        TIMEOUT 120)
+endif ()

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -215,6 +215,7 @@ add_definitions(-DHAVE_LIBFSWATCH_CONFIG_H)
 
 add_library(libfswatch ${LIB_SOURCE_FILES} ${LIBFSWATCH_HEADER_FILES})
 set_target_properties(libfswatch PROPERTIES PREFIX "")
+target_compile_features(libfswatch PUBLIC cxx_std_17)
 
 # check for gettext and libintl
 if (USE_NLS)

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -240,14 +240,18 @@ install(TARGETS libfswatch
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-# TODO: should migrate to target_source(file_set) to install headers
-install(DIRECTORY src/libfswatch
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    FILES_MATCHING
-    PATTERN "*.hpp"
-    PATTERN "*.h"
-    PATTERN ".deps" EXCLUDE
-    PATTERN ".libs" EXCLUDE)
+
+set(LIBFSWATCH_INSTALL_HEADER_FILES ${LIBFSWATCH_HEADER_FILES})
+list(REMOVE_ITEM LIBFSWATCH_INSTALL_HEADER_FILES
+    src/libfswatch/gettext.h
+    src/libfswatch/gettext_defs.h
+    "${CMAKE_CURRENT_BINARY_DIR}/libfswatch_config.h")
+foreach (header_file IN LISTS LIBFSWATCH_INSTALL_HEADER_FILES)
+    get_filename_component(header_dir "${header_file}" DIRECTORY)
+    string(REGEX REPLACE "^src/libfswatch/?" "" header_install_subdir "${header_dir}")
+    install(FILES "${header_file}"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libfswatch/${header_install_subdir}")
+endforeach ()
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libfswatch_config.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libfswatch")
 
@@ -277,6 +281,12 @@ if (BUILD_TESTING)
             -DTEST_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
             -DTEST_GENERATOR_TOOLSET=${CMAKE_GENERATOR_TOOLSET}
             -DTEST_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DTEST_HAVE_FANOTIFY=${HAVE_FANOTIFY}
+            -DTEST_HAVE_FSEVENTS=${HAVE_FSEVENTS_FSEVENTSTREAMSETDISPATCHQUEUE}
+            -DTEST_HAVE_INOTIFY_MONITOR=${HAVE_INOTIFY_MONITOR}
+            -DTEST_HAVE_PORT_H=${HAVE_PORT_H}
+            -DTEST_HAVE_SYS_EVENT_H=${HAVE_SYS_EVENT_H}
+            -DTEST_HAVE_WINDOWS=${HAVE_WINDOWS}
             -P ${PROJECT_SOURCE_DIR}/test/cmake/libfswatch_package_consumer.cmake)
     set_tests_properties(libfswatch_package_consumer PROPERTIES
         LABELS "package;cmake"

--- a/libfswatch/CMakeLists.txt
+++ b/libfswatch/CMakeLists.txt
@@ -14,6 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 # Define symbols to conditionally define FSEvents flags
 if(APPLE)
     if (${CMAKE_SYSTEM_VERSION} VERSION_GREATER_EQUAL "9.0")
@@ -220,17 +223,46 @@ if (USE_NLS)
     endif ()
 endif ()
 
-target_include_directories(libfswatch PUBLIC src/libfswatch)
-target_include_directories(libfswatch PUBLIC src)
-target_include_directories(libfswatch PUBLIC ${Intl_INCLUDE_DIRS})
+target_include_directories(libfswatch PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libfswatch>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libfswatch>
+        ${Intl_INCLUDE_DIRS})
 target_include_directories(libfswatch PRIVATE ${PROJECT_BINARY_DIR})
 target_include_directories(libfswatch PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(libfswatch PRIVATE ${EXTRA_LIBS})
 
-install(TARGETS libfswatch LIBRARY DESTINATION lib)
+set(LIBFSWATCH_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/libfswatch")
+
+install(TARGETS libfswatch
+    EXPORT libfswatchTargets
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 # TODO: should migrate to target_source(file_set) to install headers
 install(DIRECTORY src/libfswatch
-    DESTINATION include
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     FILES_MATCHING
     PATTERN "*.hpp"
-    PATTERN "*.h")
+    PATTERN "*.h"
+    PATTERN ".deps" EXCLUDE
+    PATTERN ".libs" EXCLUDE)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libfswatch_config.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libfswatch")
+
+configure_package_config_file(
+    cmake/libfswatchConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/libfswatchConfig.cmake"
+    INSTALL_DESTINATION "${LIBFSWATCH_INSTALL_CMAKEDIR}")
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/libfswatchConfigVersion.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMajorVersion)
+install(EXPORT libfswatchTargets
+    NAMESPACE libfswatch::
+    DESTINATION "${LIBFSWATCH_INSTALL_CMAKEDIR}")
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/libfswatchConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/libfswatchConfigVersion.cmake"
+    DESTINATION "${LIBFSWATCH_INSTALL_CMAKEDIR}")

--- a/libfswatch/cmake/libfswatchConfig.cmake.in
+++ b/libfswatch/cmake/libfswatchConfig.cmake.in
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libfswatchTargets.cmake")
+
+check_required_components(libfswatch)

--- a/test/cmake/libfswatch_package_consumer.cmake
+++ b/test/cmake/libfswatch_package_consumer.cmake
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+foreach(required_var TEST_BUILD_DIR TEST_WORK_DIR TEST_GENERATOR)
+    if (NOT DEFINED ${required_var})
+        message(FATAL_ERROR "${required_var} is required")
+    endif ()
+endforeach()
+
+get_filename_component(TEST_BUILD_DIR "${TEST_BUILD_DIR}" ABSOLUTE)
+get_filename_component(TEST_WORK_DIR "${TEST_WORK_DIR}" ABSOLUTE)
+string(FIND "${TEST_WORK_DIR}/" "${TEST_BUILD_DIR}/" work_dir_in_build_dir)
+if (NOT work_dir_in_build_dir EQUAL 0)
+    message(FATAL_ERROR "Refusing to write outside the build tree: ${TEST_WORK_DIR}")
+endif ()
+
+set(install_dir "${TEST_WORK_DIR}/install")
+set(consumer_source_dir "${TEST_WORK_DIR}/consumer")
+set(consumer_build_dir "${TEST_WORK_DIR}/consumer-build")
+
+file(REMOVE_RECURSE "${TEST_WORK_DIR}")
+file(MAKE_DIRECTORY "${consumer_source_dir}" "${consumer_build_dir}")
+
+set(config_args)
+if (DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
+    list(APPEND config_args --config "${TEST_CONFIG}")
+endif ()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" --install "${TEST_BUILD_DIR}" --prefix "${install_dir}" ${config_args}
+    RESULT_VARIABLE install_result)
+if (NOT install_result EQUAL 0)
+    message(FATAL_ERROR "Could not install libfswatch package test prefix")
+endif ()
+
+file(WRITE "${consumer_source_dir}/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.14)
+project(libfswatch_package_consumer LANGUAGES CXX)
+
+find_package(libfswatch CONFIG REQUIRED
+  PATHS ${CMAKE_PREFIX_PATH}
+  NO_DEFAULT_PATH)
+
+add_executable(consumer main.cpp)
+target_link_libraries(consumer PRIVATE libfswatch::libfswatch)
+]=])
+
+file(WRITE "${consumer_source_dir}/main.cpp" [=[
+#include <libfswatch/c/libfswatch.h>
+
+int main()
+{
+  return fsw_init_library() == FSW_OK ? 0 : 1;
+}
+]=])
+
+set(generator_args -G "${TEST_GENERATOR}")
+if (DEFINED TEST_GENERATOR_PLATFORM AND NOT TEST_GENERATOR_PLATFORM STREQUAL "")
+    list(APPEND generator_args -A "${TEST_GENERATOR_PLATFORM}")
+endif ()
+if (DEFINED TEST_GENERATOR_TOOLSET AND NOT TEST_GENERATOR_TOOLSET STREQUAL "")
+    list(APPEND generator_args -T "${TEST_GENERATOR_TOOLSET}")
+endif ()
+
+set(compiler_args)
+if (DEFINED TEST_CXX_COMPILER AND NOT TEST_CXX_COMPILER STREQUAL "")
+    list(APPEND compiler_args "-DCMAKE_CXX_COMPILER=${TEST_CXX_COMPILER}")
+endif ()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+        -S "${consumer_source_dir}"
+        -B "${consumer_build_dir}"
+        ${generator_args}
+        ${compiler_args}
+        "-DCMAKE_PREFIX_PATH=${install_dir}"
+    RESULT_VARIABLE configure_result)
+if (NOT configure_result EQUAL 0)
+    message(FATAL_ERROR "Could not configure libfswatch package consumer")
+endif ()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" --build "${consumer_build_dir}" ${config_args}
+    RESULT_VARIABLE build_result)
+if (NOT build_result EQUAL 0)
+    message(FATAL_ERROR "Could not build libfswatch package consumer")
+endif ()

--- a/test/cmake/libfswatch_package_consumer.cmake
+++ b/test/cmake/libfswatch_package_consumer.cmake
@@ -58,14 +58,45 @@ add_executable(consumer main.cpp)
 target_link_libraries(consumer PRIVATE libfswatch::libfswatch)
 ]=])
 
-file(WRITE "${consumer_source_dir}/main.cpp" [=[
+set(consumer_main [=[
 #include <libfswatch/c/libfswatch.h>
+#include <libfswatch/c++/event.hpp>
+#include <libfswatch/c++/filter.hpp>
+#include <libfswatch/c++/libfswatch_exception.hpp>
+#include <libfswatch/c++/monitor.hpp>
+#include <libfswatch/c++/monitor_factory.hpp>
+#include <libfswatch/c++/path_utils.hpp>
+#include <libfswatch/c++/poll_monitor.hpp>
+#include <libfswatch/c++/string/string_utils.hpp>
+]=])
+
+if (TEST_HAVE_FANOTIFY)
+    string(APPEND consumer_main "#include <libfswatch/c++/fanotify_monitor.hpp>\n")
+endif ()
+if (TEST_HAVE_FSEVENTS)
+    string(APPEND consumer_main "#include <libfswatch/c++/fsevents_monitor.hpp>\n")
+endif ()
+if (TEST_HAVE_INOTIFY_MONITOR)
+    string(APPEND consumer_main "#include <libfswatch/c++/inotify_monitor.hpp>\n")
+endif ()
+if (TEST_HAVE_PORT_H)
+    string(APPEND consumer_main "#include <libfswatch/c++/fen_monitor.hpp>\n")
+endif ()
+if (TEST_HAVE_SYS_EVENT_H)
+    string(APPEND consumer_main "#include <libfswatch/c++/kqueue_monitor.hpp>\n")
+endif ()
+if (TEST_HAVE_WINDOWS)
+    string(APPEND consumer_main "#include <libfswatch/c++/windows_monitor.hpp>\n")
+endif ()
+
+string(APPEND consumer_main [=[
 
 int main()
 {
   return fsw_init_library() == FSW_OK ? 0 : 1;
 }
 ]=])
+file(WRITE "${consumer_source_dir}/main.cpp" "${consumer_main}")
 
 set(generator_args -G "${TEST_GENERATOR}")
 if (DEFINED TEST_GENERATOR_PLATFORM AND NOT TEST_GENERATOR_PLATFORM STREQUAL "")


### PR DESCRIPTION
## Summary

- install libfswatch CMake package config/version files and exported targets
- install static/shared/runtime library artifacts with GNUInstallDirs
- install only enabled public libfswatch headers plus the generated config header
- add a CTest package-consumer check that installs to a scratch prefix and validates find_package(libfswatch CONFIG)
- document the change in NEWS and NEWS.libfswatch

Fixes #305.

## Testing

- cmake -S . -B /tmp/fswatch-header-sanity-static -DBUILD_LIBS_ONLY=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_CXX_COMPILER=/usr/bin/c++
- cmake --build /tmp/fswatch-header-sanity-static
- ctest --test-dir /tmp/fswatch-header-sanity-static -R libfswatch_package_consumer --output-on-failure
- cmake -S . -B /tmp/fswatch-header-sanity-shared -DBUILD_LIBS_ONLY=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_CXX_COMPILER=/usr/bin/c++
- cmake --build /tmp/fswatch-header-sanity-shared
- ctest --test-dir /tmp/fswatch-header-sanity-shared -R libfswatch_package_consumer --output-on-failure