### PR TITLE
Document BSD xargs replacement limits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ New in 1.21.0-develop:
   * Issue 305: Install CMake package configuration files for libfswatch so
     CMake consumers can use find_package(libfswatch CONFIG).
 
+  * Issue 238: Document the BSD/macOS xargs replacement-string length caveat
+    when processing fswatch output with xargs -I.
+
 
 New in 1.20.1:
 

--- a/fswatch/doc/fswatch.texi
+++ b/fswatch/doc/fswatch.texi
@@ -466,6 +466,13 @@ If you prefer using another replacement string, substitute @code{@{@}}
 with another string of your choice.
 @end itemize
 
+On BSD-derived systems, including macOS, the system @command{xargs}
+implementation may limit the size of replacement strings used by
+@option{-I}.  If commands fail when processing long path names, consider
+using a different consumer that reads @command{fswatch}'s NUL-separated
+records directly, or install GNU findutils and use @command{gxargs}
+instead of @command{xargs}.
+
 @section Detecting the Boundaries of a Batch of Changes
 @cpindex batch marker
 @opindex batch-marker@r{, detail}

--- a/man/fswatch.7.in
+++ b/man/fswatch.7.in
@@ -559,6 +559,18 @@ replacement string, substitute
 .Em {}
 with yours.
 .El
+.Pp
+On BSD-derived systems, including macOS, the system
+.Em xargs
+implementation may limit the size of replacement strings used by
+.Fl I .
+If commands fail when processing long path names, consider using a different
+consumer that reads
+.Nm Ns 's
+NUL-separated records directly, or install GNU findutils and use
+.Em gxargs
+instead of
+.Em xargs .
 .Ss Bubbling Events
 An often requested feature is being able to receive a single event "per batch",
 instead of receiving multiple events.  This use case is implemented by the


### PR DESCRIPTION
## Summary

- Document the BSD/macOS `xargs -I replacement-string` limit in the output-processing manual section.
- Suggest consuming fswatch's NUL-separated records directly or using GNU gxargs from findutils for long paths.
- Add the change to `NEWS` under `1.21.0-develop`.

## Issue

Closes #238.

## Validation

- Documentation-only change; reviewed the resulting diff.