### PR TITLE
Fix filtered root path monitoring

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ New in 1.21.0-develop:
   * Issue 305: Install CMake package configuration files for libfswatch so
     CMake consumers can use find_package(libfswatch CONFIG).
 
+  * Issue 247: Keep root paths and directories watchable during monitor setup
+    when path filters exclude their names but include matching children.
+
   * Issue 238: Document the BSD/macOS xargs replacement-string length caveat
     when processing fswatch output with xargs -I.
 

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -3,6 +3,9 @@ NEWS
 
 New in 1.21.0-develop:
 
+  * Issue 247: Keep root paths and directories watchable during monitor setup
+    when path filters exclude their names but include matching children.
+
   * Issue 305: Install CMake package configuration files and exported targets
     for libfswatch so CMake consumers can use find_package(libfswatch CONFIG).
 

--- a/libfswatch/src/libfswatch/c++/fanotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fanotify_monitor.cpp
@@ -407,7 +407,7 @@ namespace fsw
     return true;
   }
 
-  void fanotify_monitor::scan(const std::filesystem::path& path, const bool accept_non_dirs)
+  void fanotify_monitor::scan(const std::filesystem::path& path, const bool is_root_path)
   {
     try
     {
@@ -417,14 +417,13 @@ namespace fsw
 
       if (follow_symlinks && std::filesystem::is_symlink(status))
       {
-        scan(std::filesystem::read_symlink(path), accept_non_dirs);
+        scan(std::filesystem::read_symlink(path), is_root_path);
         return;
       }
 
       const bool is_dir = std::filesystem::is_directory(status);
-      if (!is_dir && !accept_non_dirs) return;
+      if (!is_dir && !is_root_path) return;
       if (!is_dir && directory_only) return;
-      if (!accept_path(path.string())) return;
       if (is_watched(path.string())) return;
       if (!add_mark(path)) return;
       if (!recursive || !is_dir) return;
@@ -445,7 +444,7 @@ namespace fsw
   {
     for (const std::string& path : paths)
     {
-      if (!is_watched(path)) scan(path);
+      if (!is_watched(path)) scan(path, true);
     }
   }
 

--- a/libfswatch/src/libfswatch/c++/fanotify_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/fanotify_monitor.hpp
@@ -62,7 +62,7 @@ namespace fsw
 
     void initialize();
     void scan_root_paths();
-    void scan(const std::filesystem::path& path, bool accept_non_dirs = true);
+    void scan(const std::filesystem::path& path, bool is_root_path = false);
     bool add_mark(const std::filesystem::path& path);
     bool is_watched(const std::string& path) const;
     void process_pending_paths();

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -243,7 +243,7 @@ namespace fsw
     return (inotify_desc != -1);
   }
 
-  void inotify_monitor::scan(const std::filesystem::path& path, const bool accept_non_dirs)
+  void inotify_monitor::scan(const std::filesystem::path& path, const bool is_root_path)
   {
     try 
     {
@@ -258,7 +258,7 @@ namespace fsw
       if (follow_symlinks && std::filesystem::is_symlink(status))
       {
         auto link_path = std::filesystem::read_symlink(path);
-        scan(link_path, accept_non_dirs);
+        scan(link_path, is_root_path);
         return;
       }
 
@@ -267,15 +267,15 @@ namespace fsw
       /*
       * When watching a directory the inotify API will return change events of
       * first-level children.  Therefore, we do not need to manually add a watch
-      * for a child unless it is a directory.  By default, accept_non_dirs is
-      * true to allow watching a file when first invoked on a node.
+      * for a child unless it is a directory.  Directories and root paths must
+      * remain watchable so output filters do not prevent discovery of matching
+      * children.
       *
       * For the same reason, the directory_only flag is ignored and treated as if
       * it were always set to true.
       */
-      if (!is_dir && !accept_non_dirs) return;
+      if (!is_dir && !is_root_path) return;
       if (!is_dir && directory_only) return;
-      if (!accept_path(path)) return;
       if (!add_watch(path)) return;
       if (!recursive || !is_dir) return;
 
@@ -302,7 +302,7 @@ namespace fsw
   {
     for (const std::string& path : paths)
     {
-      if (!is_watched(path)) scan(path);
+      if (!is_watched(path)) scan(path, true);
     }
   }
 

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
@@ -82,7 +82,7 @@ namespace fsw
     void preprocess_dir_event(const struct inotify_event *event);
     void preprocess_event(const struct inotify_event *event);
     void preprocess_node_event(const struct inotify_event *event);
-    void scan(const std::filesystem::path& path, const bool accept_non_dirs = true);
+    void scan(const std::filesystem::path& path, bool is_root_path = false);
     bool add_watch(const std::string& path);
     void process_pending_events();
     void process_synthetic_events();

--- a/libfswatch/src/libfswatch/c++/kqueue_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/kqueue_monitor.cpp
@@ -177,7 +177,7 @@ namespace fsw
     return true;
   }
 
-  void kqueue_monitor::scan(const std::filesystem::path& path)
+  void kqueue_monitor::scan(const std::filesystem::path& path, const bool is_root_path)
   {
     try
     {
@@ -192,7 +192,7 @@ namespace fsw
       if (follow_symlinks && std::filesystem::is_symlink(status))
       {
         const auto link_path = std::filesystem::read_symlink(path);
-        scan(link_path);
+        scan(link_path, is_root_path);
         return;
       }
 
@@ -202,7 +202,7 @@ namespace fsw
       // except for the case of root paths, where the user explicitly asked to
       // watch the file itself.
       if (!is_dir && directory_only) return;
-      if (!accept_path(path)) return;
+      if (!is_root_path && !is_dir && !accept_path(path)) return;
 
       // TODO: C++17 doesn't provide a single, comparable, type to represent st_mode
       struct stat fd_stat;
@@ -217,7 +217,7 @@ namespace fsw
 
       for (const auto& entry : entries)
       {
-        scan(entry);
+        scan(entry, false);
       }
     }
     catch (const std::filesystem::filesystem_error& e) 
@@ -270,7 +270,7 @@ namespace fsw
     {
       if (is_path_watched(path)) continue;
 
-      scan(path);
+      scan(path, true);
     }
   }
 

--- a/libfswatch/src/libfswatch/c++/kqueue_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/kqueue_monitor.hpp
@@ -77,7 +77,7 @@ namespace fsw
 
     void initialize_kqueue();
     void terminate_kqueue();
-    void scan(const std::filesystem::path& path);
+    void scan(const std::filesystem::path& path, bool is_root_path = false);
     bool add_watch(const std::string& path, const struct stat& fd_stat);
     bool is_path_watched(const std::string& path) const;
     void remove_deleted();

--- a/libfswatch/src/libfswatch/c++/poll_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/poll_monitor.cpp
@@ -120,7 +120,9 @@ namespace fsw
     return poll_callback(path, fd_stat);
   }
 
-  void poll_monitor::scan(const path& path, const path_visitor& fn)
+  void poll_monitor::scan(const path& path,
+                          const path_visitor& fn,
+                          const bool is_root_path)
   {
     try
     {
@@ -135,19 +137,18 @@ namespace fsw
       if (follow_symlinks && std::filesystem::is_symlink(status))
       {
         auto link_path = std::filesystem::read_symlink(path);
-        scan(link_path, fn);
+        scan(link_path, fn, is_root_path);
         return;
       }
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
       fsw_log_perror("Poll monitor on Windows requires Cygwin");
 #else
-      if (!accept_path(path)) return;
-
       // TODO: C++17 doesn't standardize access to ctime, so we need to keep
       // using lstat for now.
       struct stat fd_stat;
       if (!stat_path(path, fd_stat, follow_symlinks)) return;
+      if (!is_root_path && !S_ISDIR(fd_stat.st_mode) && !accept_path(path)) return;
 
       if (!add_path(path, fd_stat, fn)) return;
       if (!recursive) return;
@@ -158,7 +159,7 @@ namespace fsw
 
       for (const auto& entry : entries)
       {
-        scan(entry.path(), fn);
+        scan(entry.path(), fn, false);
       }
     }
     catch (const std::filesystem::filesystem_error& e)
@@ -195,7 +196,7 @@ namespace fsw
 
     for (const string& path : paths)
     {
-      scan(path, fn);
+      scan(path, fn, true);
     }
 
     find_removed_files();
@@ -211,7 +212,7 @@ namespace fsw
 
     for (const string& path : paths)
     {
-      scan(path, fn);
+      scan(path, fn, true);
     }
   }
 

--- a/libfswatch/src/libfswatch/c++/poll_monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/poll_monitor.hpp
@@ -77,7 +77,9 @@ namespace fsw
 
     struct poll_monitor_data;
 
-    void scan(const std::filesystem::path& path, const path_visitor& fn);
+    void scan(const std::filesystem::path& path,
+              const path_visitor& fn,
+              bool is_root_path = false);
     void collect_initial_data();
     void collect_data();
     bool add_path(const std::string& path,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,6 +26,8 @@ TESTS =
 EXTRA_DIST =
 check_PROGRAMS =
 
+TESTS += poll_filter_root_path.sh
+
 if USE_INOTIFY
   check_PROGRAMS += inotify_stop_latency_test
   check_PROGRAMS += inotify_stop_with_pending_events_test
@@ -43,6 +45,7 @@ if USE_INOTIFY
   TESTS += inotify_burst_create.sh
   TESTS += inotify_queue_drain.sh
   TESTS += inotify_recursive_create.sh
+  TESTS += inotify_filter_root_path.sh
   TESTS += inotify_stop_latency_test
   TESTS += inotify_stop_with_pending_events_test
   TESTS += inotify_stop_with_ready_events_test
@@ -52,6 +55,11 @@ if USE_FANOTIFY
   TESTS += fanotify_basic.sh
   TESTS += fanotify_access_events.sh
   TESTS += fanotify_unlimited_properties.sh
+  TESTS += fanotify_filter_root_path.sh
+endif
+
+if USE_FSEVENTS
+  TESTS += fsevents_filter_root_path.sh
 endif
 
 EXTRA_DIST += inotify_basic_events.sh
@@ -62,6 +70,11 @@ EXTRA_DIST += inotify_watched_directory_replace.sh
 EXTRA_DIST += inotify_burst_create.sh
 EXTRA_DIST += inotify_queue_drain.sh
 EXTRA_DIST += inotify_recursive_create.sh
+EXTRA_DIST += inotify_filter_root_path.sh
+EXTRA_DIST += poll_filter_root_path.sh
+EXTRA_DIST += filter_root_path.sh
 EXTRA_DIST += fanotify_basic.sh
 EXTRA_DIST += fanotify_access_events.sh
 EXTRA_DIST += fanotify_unlimited_properties.sh
+EXTRA_DIST += fanotify_filter_root_path.sh
+EXTRA_DIST += fsevents_filter_root_path.sh

--- a/test/fanotify_filter_root_path.sh
+++ b/test/fanotify_filter_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_path.sh" "${1:-${FSWATCH:-}}" fanotify_monitor

--- a/test/filter_root_path.sh
+++ b/test/filter_root_path.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 2 ]; then
+  echo "usage: $0 [FSWATCH] [MONITOR]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+MONITOR=${2:-${MONITOR:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+if [ -z "${MONITOR}" ]; then
+  echo "MONITOR is required" >&2
+  exit 2
+fi
+if ! "${FSWATCH}" -M | grep -q "^  ${MONITOR}$"; then
+  echo "${MONITOR} is not built on this platform" >&2
+  exit 77
+fi
+
+check_fsevents_available() {
+  CHECKDIR="${WORKDIR}/fsevents-check"
+  mkdir "${CHECKDIR}"
+
+  "${FSWATCH}" -m "${MONITOR}" -r --format '%p %f' --event Created \
+    "${CHECKDIR}" > "${WORKDIR}/fsevents-check.out" 2> "${WORKDIR}/fsevents-check.err" &
+  CHECK_PID=$!
+
+  sleep 1
+  echo check > "${CHECKDIR}/check.txt"
+
+  found=
+  attempt=0
+  while [ "${attempt}" -lt 10 ]; do
+    if grep -Eq '/check\.txt .*Created' "${WORKDIR}/fsevents-check.out"; then
+      found=1
+      break
+    fi
+
+    if ! kill -0 "${CHECK_PID}" 2>/dev/null; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  kill "${CHECK_PID}" 2>/dev/null || true
+  wait "${CHECK_PID}" 2>/dev/null || true
+  CHECK_PID=
+
+  if [ -z "${found}" ]; then
+    echo "fsevents did not deliver a basic create event in this environment" >&2
+    sed -n '1,80p' "${WORKDIR}/fsevents-check.err" >&2
+    exit 77
+  fi
+}
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-filter-root.XXXXXX")
+PID=
+CHECK_PID=
+
+cleanup() {
+  if [ -n "${CHECK_PID}" ]; then
+    kill "${CHECK_PID}" 2>/dev/null || true
+    wait "${CHECK_PID}" 2>/dev/null || true
+  fi
+
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+if [ "${MONITOR}" = "fsevents_monitor" ]; then
+  check_fsevents_available
+fi
+
+TESTDIR="${WORKDIR}/watched-root"
+mkdir "${TESTDIR}"
+
+"${FSWATCH}" -m "${MONITOR}" -r --format '%p %f' --event Created \
+  -e '.*' -i '\.txt$' "${TESTDIR}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+if ! kill -0 "${PID}" 2>/dev/null; then
+  if [ "${MONITOR}" = "fanotify_monitor" ] &&
+     grep -Eqi 'fanotify|permission|operation not permitted|not supported|Cannot initialize' "${WORKDIR}/err.log"; then
+    echo "fanotify is unavailable in this environment" >&2
+    sed -n '1,120p' "${WORKDIR}/err.log" >&2
+    exit 77
+  fi
+
+  echo "${MONITOR} exited unexpectedly" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi
+
+mkdir "${TESTDIR}/nested"
+sleep 1
+
+echo ignored > "${TESTDIR}/ignored.bin"
+echo matching > "${TESTDIR}/matching.txt"
+echo nested-ignored > "${TESTDIR}/nested/ignored.bin"
+echo nested-matching > "${TESTDIR}/nested/matching.txt"
+
+assert_event() {
+  pattern=$1
+  description=$2
+  found=
+  attempt=0
+
+  while [ "${attempt}" -lt 10 ]; do
+    if grep -Eq "${pattern}" "${WORKDIR}/out.log"; then
+      found=1
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  if [ -z "${found}" ]; then
+    echo "missing ${description}" >&2
+    echo "--- fswatch output ---" >&2
+    sed -n '1,160p' "${WORKDIR}/out.log" >&2
+    echo "--- fswatch stderr ---" >&2
+    sed -n '1,80p' "${WORKDIR}/err.log" >&2
+    exit 1
+  fi
+}
+
+assert_event '/matching\.txt .*Created' 'matching child event through excluded root path'
+assert_event '/nested/matching\.txt .*Created' 'matching nested child event through excluded directory path'
+
+sleep 1
+
+if grep -Eq 'ignored\.bin' "${WORKDIR}/out.log"; then
+  echo "nonmatching child escaped path filters" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,80p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/fsevents_filter_root_path.sh
+++ b/test/fsevents_filter_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_path.sh" "${1:-${FSWATCH:-}}" fsevents_monitor

--- a/test/inotify_filter_root_path.sh
+++ b/test/inotify_filter_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_path.sh" "${1:-${FSWATCH:-}}" inotify_monitor

--- a/test/poll_filter_root_path.sh
+++ b/test/poll_filter_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_path.sh" "${1:-${FSWATCH:-}}" poll_monitor

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -111,6 +111,15 @@ if (BUILD_TESTING)
                     LABELS "integration;inotify"
                     TIMEOUT 25)
 
+            add_test(NAME inotify_filter_root_path
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/filter_root_path.sh
+                            $<TARGET_FILE:fswatch>
+                            inotify_monitor)
+            set_tests_properties(inotify_filter_root_path PROPERTIES
+                    LABELS "integration;inotify;filtering"
+                    TIMEOUT 15)
+
             if (GIT_EXECUTABLE)
                 add_test(NAME inotify_recursive_create
                         COMMAND ${SH_EXECUTABLE}
@@ -123,6 +132,17 @@ if (BUILD_TESTING)
             endif ()
         endif ()
 
+    endif ()
+
+    if (SH_EXECUTABLE)
+        add_test(NAME poll_filter_root_path
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/filter_root_path.sh
+                        $<TARGET_FILE:fswatch>
+                        poll_monitor)
+        set_tests_properties(poll_filter_root_path PROPERTIES
+                LABELS "integration;poll;filtering"
+                TIMEOUT 20)
     endif ()
 
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND SH_EXECUTABLE AND HAVE_FANOTIFY)
@@ -152,6 +172,16 @@ if (BUILD_TESTING)
                 LABELS "integration;fanotify"
                 SKIP_RETURN_CODE 77
                 TIMEOUT 20)
+
+        add_test(NAME fanotify_filter_root_path
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/filter_root_path.sh
+                        $<TARGET_FILE:fswatch>
+                        fanotify_monitor)
+        set_tests_properties(fanotify_filter_root_path PROPERTIES
+                LABELS "integration;fanotify;filtering"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
     endif ()
 
     if (APPLE)
@@ -168,5 +198,17 @@ if (BUILD_TESTING)
         target_include_directories(fsevents_cf_paths_test PRIVATE ../.. .)
         target_link_libraries(fsevents_cf_paths_test PUBLIC libfswatch ${CORESERVICES_LIBRARY})
         add_test(NAME fsevents_cf_paths_test COMMAND fsevents_cf_paths_test)
+
+        if (SH_EXECUTABLE)
+            add_test(NAME fsevents_filter_root_path
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/filter_root_path.sh
+                            $<TARGET_FILE:fswatch>
+                            fsevents_monitor)
+            set_tests_properties(fsevents_filter_root_path PROPERTIES
+                    LABELS "integration;fsevents;filtering"
+                    SKIP_RETURN_CODE 77
+                    TIMEOUT 20)
+        endif ()
     endif ()
 endif ()


### PR DESCRIPTION
## Summary

Fixes issue #247 by keeping watched root paths and directories discoverable even when path filters reject their own names. Events are still filtered before notification, but recursive monitors no longer lose matching descendants because an excluded root or intermediate directory was skipped during setup or scanning.

This updates the recursive scan behavior for inotify, fanotify, poll, and kqueue monitors. FSEvents already delegates recursive discovery to macOS, so it gets regression coverage rather than implementation changes.

## Tests

Added shared filter-root integration coverage and wired it into both build systems for poll, inotify, fanotify, and fsevents.

Local validation:

- cmake --build build --target fswatch
- ctest --test-dir build --output-on-failure with host permissions: 5/5 passed
- make -j4
- make -C test check TESTS=poll_filter_root_path.sh
- make -C test check TESTS=fsevents_filter_root_path.sh skips in sandboxed execution when FSEvents delivery is unavailable
- git diff --check

Linux CI should validate the inotify and fanotify runtime paths.