### PR TITLE
Add recursive traversal pruning

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ NEWS
 
 New in 1.21.0-develop:
 
+  * Issue 151: Add --prune to prevent recursive traversal from descending into
+    matching directories.
+
   * Issue 305: Install CMake package configuration files for libfswatch so
     CMake consumers can use find_package(libfswatch CONFIG).
 

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -3,6 +3,10 @@ NEWS
 
 New in 1.21.0-develop:
 
+  * Issue 151: Add traversal prune filters to libfswatch so recursive monitors
+    can skip matching directories before scanning or watching their
+    descendants.
+
   * Issue 247: Keep root paths and directories watchable during monitor setup
     when path filters exclude their names but include matching children.
 

--- a/fswatch/doc/fswatch.texi
+++ b/fswatch/doc/fswatch.texi
@@ -859,6 +859,12 @@ Exit @command{fswatch} after the first set of events is received.
 
 Use the @acronym{ASCII} @samp{NUL} (@samp{\0}) as record separator.
 
+@opsummary{prune}
+@item --prune
+
+Do not descend into directories matching @command{@var{regex}} during
+recursive traversal.  This option can be specified multiple times.
+
 @opsummary{recursive}
 @item --recursive
 @itemx -r
@@ -1266,6 +1272,30 @@ Inclusion filters may override any other exclusion filter.
 @item
 The order in the definition of filters in the command line has no effect.
 @end itemize
+
+@subsection Pruning Recursive Traversal
+@cpindex path filter, pruning
+@opindex prune@r{, detail}
+The @option{--prune} option defines regular expressions that stop
+recursive traversal from descending into matching directories.  This is
+different from @option{--exclude}: excluded paths are filtered from
+the resulting events, while pruned directories and their descendants
+are not scanned or monitored by recursive monitors that traverse
+directory trees.
+
+Prune expressions use the same case-sensitivity and extended-regular
+expression settings as normal path filters.
+
+Pruning is applied only to non-root directories.  A command-line root
+path remains eligible for monitoring even if it matches a prune
+expression.
+
+For example, the following command recursively watches @file{/home/me}
+without descending into hidden directories:
+
+@example
+$ fswatch -r --prune '/\.[^/]+$' /home/me
+@end example
 
 @subsection Filter Modifiers
 @cpindex path filter, modifier

--- a/fswatch/src/fswatch.cpp
+++ b/fswatch/src/fswatch.cpp
@@ -86,6 +86,7 @@ static const unsigned int TIME_FORMAT_BUFF_SIZE = 128;
 
 static monitor *active_monitor = nullptr;
 static std::vector<monitor_filter> filters;
+static std::vector<monitor_filter> prune_filters;
 static std::vector<fsw_event_type_filter> event_filters;
 static std::vector<std::string> filter_files;
 static bool _0flag = false;
@@ -131,6 +132,7 @@ static const int OPT_MONITOR_PROPERTY = 133;
 static const int OPT_FIRE_IDLE_EVENTS = 134;
 static const int OPT_FILTER_FROM = 135;
 static const int OPT_NO_DEFER = 136;
+static const int OPT_PRUNE = 137;
 
 static void list_monitor_types(std::ostream& stream)
 {
@@ -189,6 +191,7 @@ static void usage(std::ostream& stream)
   stream << "                       " << _("Define the specified property.\n");
   stream << " -n, --numeric         " << _("Print a numeric event mask.\n");
   stream << " -o, --one-per-batch   " << _("Print a single message with the number of change events.\n");
+  stream << "     --prune=REGEX     " << _("Do not descend into directories matching REGEX.\n");
   stream << " -r, --recursive       " << _("Recurse subdirectories.\n");
   stream << " -t, --timestamp       " << _("Print the event timestamp.\n");
   stream << " -u, --utc-time        " << _("Print the event time as UTC time.\n");
@@ -499,6 +502,12 @@ static void start_monitor(int argc, char **argv, int argIndex)
     filter.extended = Eflag;
   }
 
+  for (auto& filter : prune_filters)
+  {
+    filter.case_sensitive = !Iflag;
+    filter.extended = Eflag;
+  }
+
   // Load filters from the specified files.
   for (const auto& filter_file : filter_files)
   {
@@ -527,6 +536,7 @@ static void start_monitor(int argc, char **argv, int argIndex)
   active_monitor->set_directory_only(dflag);
   active_monitor->set_event_type_filters(event_filters);
   active_monitor->set_filters(filters);
+  active_monitor->set_prune_filters(prune_filters);
   active_monitor->set_follow_symlinks(Lflag);
   active_monitor->set_watch_access(aflag);
   active_monitor->set_bubble_events(bflag);
@@ -571,6 +581,7 @@ static void parse_opts(int argc, char **argv)
     {"one-per-batch",        no_argument,       nullptr,       'o'},
     {"one-event",            no_argument,       nullptr,       '1'},
     {"print0",               no_argument,       nullptr,       '0'},
+    {"prune",                required_argument, nullptr,       OPT_PRUNE},
     {"recursive",            no_argument,       nullptr,       'r'},
     {"timestamp",            no_argument,       nullptr,       't'},
     {"utc-time",             no_argument,       nullptr,       'u'},
@@ -723,6 +734,10 @@ static void parse_opts(int argc, char **argv)
 
     case OPT_FILTER_FROM:
       filter_files.emplace_back(optarg);
+      break;
+
+    case OPT_PRUNE:
+      prune_filters.push_back({optarg, fsw_filter_type::filter_exclude});
       break;
 
     case OPT_NO_DEFER:

--- a/libfswatch/src/libfswatch/c++/fanotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fanotify_monitor.cpp
@@ -422,6 +422,7 @@ namespace fsw
       }
 
       const bool is_dir = std::filesystem::is_directory(status);
+      if (should_prune_path(path.string(), is_dir, is_root_path)) return;
       if (!is_dir && !is_root_path) return;
       if (!is_dir && directory_only) return;
       if (is_watched(path.string())) return;

--- a/libfswatch/src/libfswatch/c++/fen_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fen_monitor.cpp
@@ -275,6 +275,7 @@ namespace fsw
       }
 
       bool is_dir = S_ISDIR(fd_stat.st_mode);
+      if (should_prune_path(path.string(), is_dir, is_root_path)) return true;
 
       if (!is_dir && !is_root_path && directory_only) return true;
       if (!is_dir && !accept_path(path)) return true;

--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -263,6 +263,7 @@ namespace fsw
       }
 
       const bool is_dir = std::filesystem::is_directory(status);
+      if (should_prune_path(path.string(), is_dir, is_root_path)) return;
 
       /*
       * When watching a directory the inotify API will return change events of

--- a/libfswatch/src/libfswatch/c++/kqueue_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/kqueue_monitor.cpp
@@ -197,6 +197,7 @@ namespace fsw
       }
 
       const bool is_dir = std::filesystem::is_directory(status);
+      if (should_prune_path(path.string(), is_dir, is_root_path)) return;
 
       // Do not fall through if the monitor is set to watch directories only,
       // except for the case of root paths, where the user explicitly asked to

--- a/libfswatch/src/libfswatch/c++/monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/monitor.cpp
@@ -134,6 +134,27 @@ namespace fsw
     }
   }
 
+  void monitor::add_prune_filter(const monitor_filter& filter)
+  {
+    std::regex::flag_type regex_flags = std::regex::basic;
+
+    if (filter.extended) regex_flags = std::regex::extended;
+    if (!filter.case_sensitive) regex_flags |= std::regex::icase;
+
+    try
+    {
+      prune_filters.emplace_back(filter.text, regex_flags);
+    }
+    catch (const std::regex_error& error)
+    {
+      throw libfsw_exception(
+        string_utils::string_from_format(
+          _("An error occurred during the compilation of %s"),
+          filter.text.c_str()),
+        FSW_ERR_INVALID_REGEX);
+    }
+  }
+
   void monitor::set_property(const std::string& name, const std::string& value)
   {
     properties[name] = value;
@@ -151,9 +172,21 @@ namespace fsw
 
   void monitor::set_filters(const std::vector<monitor_filter>& filters)
   {
+    this->filters.clear();
+
     for (const monitor_filter& filter : filters)
     {
       add_filter(filter);
+    }
+  }
+
+  void monitor::set_prune_filters(const std::vector<monitor_filter>& filters)
+  {
+    prune_filters.clear();
+
+    for (const monitor_filter& filter : filters)
+    {
+      add_prune_filter(filter);
     }
   }
 
@@ -194,6 +227,18 @@ namespace fsw
     }
 
     return !is_excluded;
+  }
+
+  bool monitor::should_prune_path(const std::string& path,
+                                  bool is_dir,
+                                  bool is_root_path) const
+  {
+    if (!is_dir || is_root_path) return false;
+
+    return std::any_of(prune_filters.begin(),
+                       prune_filters.end(),
+                       [&path](const std::regex& filter)
+                       { return std::regex_search(path, filter); });
   }
 
   void *monitor::get_context() const

--- a/libfswatch/src/libfswatch/c++/monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/monitor.hpp
@@ -36,6 +36,7 @@
 #  include <atomic>
 #  include <chrono>
 #  include <map>
+#  include <regex>
 #  include "event.hpp"
 #  include "libfswatch/c/cmonitor.h"
 
@@ -310,6 +311,29 @@ namespace fsw
     void set_filters(const std::vector<monitor_filter>& filters);
 
     /**
+     * @brief Add a traversal prune filter.
+     *
+     * This function adds a monitor_filter instance to the prune filter list.
+     * Prune filters are used by recursive monitors to decide whether a
+     * non-root directory should be skipped while traversing a hierarchy.  They
+     * are not event filters: a pruned directory and its descendants are not
+     * scanned or monitored by implementations that use recursive traversal.
+     *
+     * @param filter The prune filter to add.
+     */
+    void add_prune_filter(const monitor_filter& filter);
+
+    /**
+     * @brief Set the traversal prune filters.
+     *
+     * This function sets the list of prune filters, substituting existing
+     * filters if any.
+     *
+     * @param filters The prune filters to set.
+     */
+    void set_prune_filters(const std::vector<monitor_filter>& filters);
+
+    /**
      * @brief Follow symlinks.
      *
      * This function sets the follow_symlinks flag of the monitor to indicate
@@ -457,6 +481,23 @@ namespace fsw
      * @return @c true if the path is accepted, @c false otherwise.
      */
     bool accept_path(const std::string& path) const;
+
+    /**
+     * @brief Check whether a directory should be pruned from recursive scans.
+     *
+     * This function checks @p path against the prune filters of the monitor to
+     * determine whether recursive traversal should skip it.  Root paths are
+     * never pruned by this helper so that explicit paths passed by the user
+     * remain eligible for monitor setup.
+     *
+     * @param path The path to check.
+     * @param is_dir @c true if the path is a directory.
+     * @param is_root_path @c true if the path is a monitor root.
+     * @return @c true if the directory should be pruned, @c false otherwise.
+     */
+    bool should_prune_path(const std::string& path,
+                           bool is_dir,
+                           bool is_root_path) const;
 
     /**
      * @brief Notify change events.
@@ -614,6 +655,7 @@ namespace fsw
   private:
     std::chrono::milliseconds get_latency_ms() const;
     std::vector<compiled_monitor_filter> filters;
+    std::vector<std::regex> prune_filters;
     std::vector<fsw_event_type_filter> event_type_filters;
 
     static void inactivity_callback(monitor *mon);

--- a/libfswatch/src/libfswatch/c++/poll_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/poll_monitor.cpp
@@ -148,6 +148,7 @@ namespace fsw
       // using lstat for now.
       struct stat fd_stat;
       if (!stat_path(path, fd_stat, follow_symlinks)) return;
+      if (should_prune_path(path.string(), S_ISDIR(fd_stat.st_mode), is_root_path)) return;
       if (!is_root_path && !S_ISDIR(fd_stat.st_mode) && !accept_path(path)) return;
 
       if (!add_path(path, fd_stat, fn)) return;

--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -195,6 +195,7 @@
  *     active_monitor->set_directory_only(directory_only);
  *     active_monitor->set_event_type_filters(event_filters);
  *     active_monitor->set_filters(filters);
+ *     active_monitor->set_prune_filters(prune_filters);
  *     active_monitor->set_follow_symlinks(follow_symlinks);
  *     active_monitor->set_watch_access(watch_access);
  *
@@ -433,6 +434,21 @@
  *   - Inclusion filters may override any other exclusion filter.
  *
  *   - The order in the filter definition has no effect.
+ *
+ * @section path-pruning Recursive Traversal Pruning
+ *
+ * Prune filters are separate from path filters.  A prune filter is a regular
+ * expression used by recursive monitors to decide whether traversal should
+ * descend into a non-root directory.  When a directory is pruned, that
+ * directory's descendants are not scanned or monitored by implementations that
+ * traverse directory trees.
+ *
+ * Pruning is applied before normal event filtering and is intentionally
+ * opt-in: unlike exclusion filters, prune filters can make included
+ * descendants impossible to observe.
+ *
+ * Root paths are not pruned, even if they match a prune filter, because those
+ * paths were explicitly supplied by the caller.
  */
 #include "libfswatch/gettext_defs.h"
 #include <iostream>
@@ -466,6 +482,7 @@ using FSW_SESSION = struct FSW_SESSION
   bool directory_only;
   bool follow_symlinks;
   vector<monitor_filter> filters;
+  vector<monitor_filter> prune_filters;
   vector<fsw_event_type_filter> event_type_filters;
   map<string, string> properties;
   void *data;
@@ -806,6 +823,16 @@ FSW_STATUS fsw_add_filter(const FSW_HANDLE handle,
   return fsw_set_last_error(FSW_OK);
 }
 
+FSW_STATUS fsw_add_prune_filter(const FSW_HANDLE handle,
+                                const fsw_cmonitor_filter filter)
+{
+  FSW_SESSION *session = get_session(handle);
+  session->prune_filters.push_back(
+    {filter.text, filter.type, filter.case_sensitive, filter.extended});
+
+  return fsw_set_last_error(FSW_OK);
+}
+
 bool fsw_is_running(const FSW_HANDLE handle)
 {
   FSW_SESSION *session = get_session(handle);
@@ -838,6 +865,7 @@ FSW_STATUS fsw_start_monitor(const FSW_HANDLE handle)
 
     session->monitor->set_allow_overflow(session->allow_overflow);
     session->monitor->set_filters(session->filters);
+    session->monitor->set_prune_filters(session->prune_filters);
     session->monitor->set_event_type_filters(session->event_type_filters);
     session->monitor->set_follow_symlinks(session->follow_symlinks);
     if (session->latency) session->monitor->set_latency(session->latency);

--- a/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/libfswatch/src/libfswatch/c/libfswatch.h
@@ -183,6 +183,20 @@ extern "C"
                             const fsw_cmonitor_filter filter);
 
   /**
+   * Adds a prune filter to the current session.  A prune filter is a regular
+   * expression that prevents recursive traversal from descending into matching
+   * non-root directories.  It is not an event filter: pruned directories and
+   * their descendants are not scanned or monitored by recursive monitors that
+   * traverse directory trees.
+   *
+   * See cfilter.h for the definition of fsw_cmonitor_filter.  The filter type
+   * is ignored, while the expression, case-sensitivity, and extended-regex
+   * flags are honoured.
+   */
+  FSW_STATUS fsw_add_prune_filter(const FSW_HANDLE handle,
+                                  const fsw_cmonitor_filter filter);
+
+  /**
    * Starts the monitor if it is properly configured.  Depending on the type of
    * monitor this call might return when a monitor is stopped or not.
    */

--- a/man/fswatch.7.in
+++ b/man/fswatch.7.in
@@ -168,6 +168,12 @@ across different versions of macOS.  As a consequence, the use of numeric values
 is discouraged.
 .It Fl o, -one-per-batch
 Print a single message with the number of change events.
+.It Fl -prune Ar regexp
+Do not descend into directories matching
+.Ar regexp
+during recursive traversal.  This option may be specified multiple times.  See
+.Sx FILTERING PATHS
+for further information.
 .It Fl r, -recursive
 Watch subdirectories recursively.  This option may not be supported on all
 systems.
@@ -416,6 +422,28 @@ Inclusion filters may override any other exclusion filter.
 .It -
 The order in the definition of filters in the command line has no effect.
 .El
+
+.Ss Pruning Recursive Traversal
+The
+.Fl -prune Ar regexp
+option defines regular expressions that stop recursive traversal from
+descending into matching directories.  This is different from
+.Fl -exclude :
+excluded paths are filtered from the resulting events, while pruned directories
+and their descendants are not scanned or monitored by recursive monitors that
+traverse directory trees.
+.Pp
+Prune expressions use the same case-sensitivity and extended-regular-expression
+settings as normal path filters.
+.Pp
+Pruning is applied only to non-root directories.  A command-line root path
+remains eligible for monitoring even if it matches a prune expression.
+.Pp
+For example, the following command recursively watches
+.Pa /home/me
+without descending into hidden directories:
+.Pp
+.Dl $ fswatch -r --prune '/\e.[^/]+$' /home/me
 
 .Pp
 Other options govern how regular expressions are interpreted:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST =
 check_PROGRAMS =
 
 TESTS += poll_filter_root_path.sh
+TESTS += poll_prune.sh
 
 if USE_INOTIFY
   check_PROGRAMS += inotify_stop_latency_test
@@ -46,6 +47,7 @@ if USE_INOTIFY
   TESTS += inotify_queue_drain.sh
   TESTS += inotify_recursive_create.sh
   TESTS += inotify_filter_root_path.sh
+  TESTS += inotify_prune.sh
   TESTS += inotify_stop_latency_test
   TESTS += inotify_stop_with_pending_events_test
   TESTS += inotify_stop_with_ready_events_test
@@ -56,6 +58,7 @@ if USE_FANOTIFY
   TESTS += fanotify_access_events.sh
   TESTS += fanotify_unlimited_properties.sh
   TESTS += fanotify_filter_root_path.sh
+  TESTS += fanotify_prune.sh
 endif
 
 if USE_FSEVENTS
@@ -71,10 +74,14 @@ EXTRA_DIST += inotify_burst_create.sh
 EXTRA_DIST += inotify_queue_drain.sh
 EXTRA_DIST += inotify_recursive_create.sh
 EXTRA_DIST += inotify_filter_root_path.sh
+EXTRA_DIST += inotify_prune.sh
 EXTRA_DIST += poll_filter_root_path.sh
+EXTRA_DIST += poll_prune.sh
 EXTRA_DIST += filter_root_path.sh
+EXTRA_DIST += prune.sh
 EXTRA_DIST += fanotify_basic.sh
 EXTRA_DIST += fanotify_access_events.sh
 EXTRA_DIST += fanotify_unlimited_properties.sh
 EXTRA_DIST += fanotify_filter_root_path.sh
+EXTRA_DIST += fanotify_prune.sh
 EXTRA_DIST += fsevents_filter_root_path.sh

--- a/test/fanotify_prune.sh
+++ b/test/fanotify_prune.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/prune.sh" "${1:-${FSWATCH:-}}" fanotify_monitor

--- a/test/inotify_prune.sh
+++ b/test/inotify_prune.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/prune.sh" "${1:-${FSWATCH:-}}" inotify_monitor

--- a/test/poll_prune.sh
+++ b/test/poll_prune.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/prune.sh" "${1:-${FSWATCH:-}}" poll_monitor

--- a/test/prune.sh
+++ b/test/prune.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 2 ]; then
+  echo "usage: $0 [FSWATCH] [MONITOR]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+MONITOR=${2:-${MONITOR:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+if [ -z "${MONITOR}" ]; then
+  echo "MONITOR is required" >&2
+  exit 2
+fi
+if ! "${FSWATCH}" -M | grep -q "^  ${MONITOR}$"; then
+  echo "${MONITOR} is not built on this platform" >&2
+  exit 77
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-prune.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+TESTDIR="${WORKDIR}/watched"
+PRUNED="${TESTDIR}/pruned"
+VISIBLE="${TESTDIR}/visible"
+
+mkdir -p "${PRUNED}" "${VISIBLE}"
+
+"${FSWATCH}" -m "${MONITOR}" -r --format '%p %f' --event Created \
+  --prune '/pruned$' "${TESTDIR}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+if ! kill -0 "${PID}" 2>/dev/null; then
+  if [ "${MONITOR}" = "fanotify_monitor" ] &&
+     grep -Eqi 'fanotify|permission|operation not permitted|not supported|Cannot initialize' "${WORKDIR}/err.log"; then
+    echo "fanotify is unavailable in this environment" >&2
+    sed -n '1,120p' "${WORKDIR}/err.log" >&2
+    exit 77
+  fi
+
+  echo "${MONITOR} exited unexpectedly" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi
+
+echo visible > "${VISIBLE}/visible.txt"
+echo hidden > "${PRUNED}/hidden.txt"
+
+found=
+attempt=0
+while [ "${attempt}" -lt 10 ]; do
+  if grep -Eq '/visible/visible\.txt .*Created' "${WORKDIR}/out.log"; then
+    found=1
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "missing event outside pruned directory" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,80p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi
+
+sleep 1
+
+if grep -Eq '/pruned/hidden\.txt' "${WORKDIR}/out.log"; then
+  echo "event below pruned directory was reported" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,80p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -120,6 +120,15 @@ if (BUILD_TESTING)
                     LABELS "integration;inotify;filtering"
                     TIMEOUT 15)
 
+            add_test(NAME inotify_prune
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/prune.sh
+                            $<TARGET_FILE:fswatch>
+                            inotify_monitor)
+            set_tests_properties(inotify_prune PROPERTIES
+                    LABELS "integration;inotify;filtering"
+                    TIMEOUT 15)
+
             if (GIT_EXECUTABLE)
                 add_test(NAME inotify_recursive_create
                         COMMAND ${SH_EXECUTABLE}
@@ -141,6 +150,15 @@ if (BUILD_TESTING)
                         $<TARGET_FILE:fswatch>
                         poll_monitor)
         set_tests_properties(poll_filter_root_path PROPERTIES
+                LABELS "integration;poll;filtering"
+                TIMEOUT 20)
+
+        add_test(NAME poll_prune
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/prune.sh
+                        $<TARGET_FILE:fswatch>
+                        poll_monitor)
+        set_tests_properties(poll_prune PROPERTIES
                 LABELS "integration;poll;filtering"
                 TIMEOUT 20)
     endif ()
@@ -179,6 +197,16 @@ if (BUILD_TESTING)
                         $<TARGET_FILE:fswatch>
                         fanotify_monitor)
         set_tests_properties(fanotify_filter_root_path PROPERTIES
+                LABELS "integration;fanotify;filtering"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
+
+        add_test(NAME fanotify_prune
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/prune.sh
+                        $<TARGET_FILE:fswatch>
+                        fanotify_monitor)
+        set_tests_properties(fanotify_prune PROPERTIES
                 LABELS "integration;fanotify;filtering"
                 SKIP_RETURN_CODE 77
                 TIMEOUT 20)


### PR DESCRIPTION
## Summary

- add `--prune=REGEX` to skip matching non-root directories during recursive traversal
- expose prune filters through the libfswatch C++ and C APIs
- apply pruning in recursive monitor scans and document the behavior
- add regression coverage for CMake and Autotools test runners

Closes #151.

## Verification

- `cmake --build build --target fswatch`
- `ctest --test-dir build -R prune --output-on-failure`
- `make -j4`
- `make -C test check TESTS=poll_prune.sh`
- `ctest --test-dir build -R 'filter|prune' --output-on-failure`