### PR TITLE
Add conjunctive filter mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ NEWS
 
 New in 1.21.0-develop:
 
+  * Issues 104 and 273: Add --filter-mode=conjunctive so include filters can
+    define a candidate set while exclude filters subtract from it.
+
   * Issue 151: Add --prune to prevent recursive traversal from descending into
     matching directories.
 

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -3,6 +3,9 @@ NEWS
 
 New in 1.21.0-develop:
 
+  * Issues 104 and 273: Add a conjunctive path filter mode so inclusion
+    filters define a candidate set and exclusion filters subtract from it.
+
   * Issue 151: Add traversal prune filters to libfswatch so recursive monitors
     can skip matching directories before scanning or watching their
     descendants.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Features
 
   * Support for many OS-specific APIs such as kevent, inotify, and FSEvents.
   * Recursive directory monitoring.
-  * Path filtering using including and excluding regular expressions.
+  * Path filtering using including and excluding regular expressions, with
+    legacy and conjunctive evaluation modes.
   * Customizable record format.
   * Support for periodic idle events.
 

--- a/fswatch/doc/fswatch.texi
+++ b/fswatch/doc/fswatch.texi
@@ -762,6 +762,12 @@ Use extended regular expressions.
 
 Load filters from the specified @command{@var{file}}.
 
+@opsummary{filter-mode}
+@item --filter-mode
+
+Set the path filter evaluation mode.  Supported modes are
+@samp{legacy} and @samp{conjunctive}.
+
 @opsummary{fire-idle-events}
 @item --fire-idle-events
 
@@ -1244,7 +1250,12 @@ Two types of filters are available:
 
 As their name indicates, they are used to include and exclude paths
 from the monitored object list and from resulting events.
-@command{fswatch} processes filters this way:
+@command{fswatch} supports two path filter evaluation modes:
+@samp{legacy} and @samp{conjunctive}.
+
+@samp{legacy} is the default mode and preserves the historical
+include-overrides-exclude behavior.  In this mode, @command{fswatch}
+processes filters this way:
 
 @itemize
 @item
@@ -1272,6 +1283,37 @@ Inclusion filters may override any other exclusion filter.
 @item
 The order in the definition of filters in the command line has no effect.
 @end itemize
+
+@samp{conjunctive} mode is enabled with
+@option{--filter-mode=conjunctive}.  It treats inclusion filters as the
+candidate set and exclusion filters as subtractions from that set:
+
+@itemize
+@item
+If no inclusion filters are specified, all paths are candidates.
+
+@item
+If at least one inclusion filter is specified, a path must match an
+inclusion filter to be a candidate.
+
+@item
+Any matching exclusion filter rejects the path.
+@end itemize
+
+@noindent
+Said another way, conjunctive mode accepts paths matching this
+expression:
+
+@example
+(no includes OR matches include) AND NOT matches exclude
+@end example
+
+For example, the following command reports changes to C source files
+except editor lock files:
+
+@example
+$ fswatch --filter-mode=conjunctive -i '\.c$' -e '/lock-[^/]+\.c$' .
+@end example
 
 @subsection Pruning Recursive Traversal
 @cpindex path filter, pruning

--- a/fswatch/src/fswatch.cpp
+++ b/fswatch/src/fswatch.cpp
@@ -89,6 +89,7 @@ static std::vector<monitor_filter> filters;
 static std::vector<monitor_filter> prune_filters;
 static std::vector<fsw_event_type_filter> event_filters;
 static std::vector<std::string> filter_files;
+static fsw_filter_mode filter_mode = fsw_filter_mode::filter_mode_legacy;
 static bool _0flag = false;
 static bool _1flag = false;
 static bool aflag = false;
@@ -133,6 +134,7 @@ static const int OPT_FIRE_IDLE_EVENTS = 134;
 static const int OPT_FILTER_FROM = 135;
 static const int OPT_NO_DEFER = 136;
 static const int OPT_PRUNE = 137;
+static const int OPT_FILTER_MODE = 138;
 
 static void list_monitor_types(std::ostream& stream)
 {
@@ -173,6 +175,8 @@ static void usage(std::ostream& stream)
   stream << " -E, --extended        " << _("Use extended regular expressions.\n");
   stream << "     --filter-from=FILE\n";
   stream << "                       " << _("Load filters from file.") << "\n";
+  stream << "     --filter-mode=MODE\n";
+  stream << "                       " << _("Set filter mode: legacy or conjunctive.") << "\n";
   stream << "     --format=FORMAT   " << _("Use the specified record format.") << "\n";
   stream << "                       " << _("Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, %P process id.") << "\n";
   stream << " -f, --format-time     " << _("Print the event time using the specified format.\n");
@@ -300,6 +304,26 @@ static bool parse_event_filter(const char *pOptarg)
     std::cerr << ex.what() << std::endl;
     return false;
   }
+}
+
+static bool parse_filter_mode(const char *pOptarg)
+{
+  const std::string mode(pOptarg);
+
+  if (mode == "legacy")
+  {
+    filter_mode = fsw_filter_mode::filter_mode_legacy;
+    return true;
+  }
+
+  if (mode == "conjunctive")
+  {
+    filter_mode = fsw_filter_mode::filter_mode_conjunctive;
+    return true;
+  }
+
+  std::cerr << _("Invalid filter mode: ") << pOptarg << std::endl;
+  return false;
 }
 
 static bool validate_latency(double latency, const char *pOptarg)
@@ -535,6 +559,7 @@ static void start_monitor(int argc, char **argv, int argIndex)
   active_monitor->set_recursive(rflag);
   active_monitor->set_directory_only(dflag);
   active_monitor->set_event_type_filters(event_filters);
+  active_monitor->set_filter_mode(filter_mode);
   active_monitor->set_filters(filters);
   active_monitor->set_prune_filters(prune_filters);
   active_monitor->set_follow_symlinks(Lflag);
@@ -562,6 +587,7 @@ static void parse_opts(int argc, char **argv)
     {"event-flag-separator", required_argument, nullptr,       OPT_EVENT_FLAG_SEPARATOR},
     {"exclude",              required_argument, nullptr,       'e'},
     {"extended",             no_argument,       nullptr,       'E'},
+    {"filter-mode",          required_argument, nullptr,       OPT_FILTER_MODE},
     {"filter-from",          required_argument, nullptr,       OPT_FILTER_FROM},
     {"fire-idle-events",     no_argument,       nullptr,       OPT_FIRE_IDLE_EVENTS},
     {"follow-links",         no_argument,       nullptr,       'L'},
@@ -716,7 +742,7 @@ static void parse_opts(int argc, char **argv)
     case OPT_EVENT_TYPE:
       if (!parse_event_filter(optarg))
       {
-        exit(FSW_ERR_UNKNOWN_VALUE);
+        exit(FSW_EXIT_OPT);
       }
       break;
 
@@ -734,6 +760,13 @@ static void parse_opts(int argc, char **argv)
 
     case OPT_FILTER_FROM:
       filter_files.emplace_back(optarg);
+      break;
+
+    case OPT_FILTER_MODE:
+      if (!parse_filter_mode(optarg))
+      {
+        exit(FSW_EXIT_OPT);
+      }
       break;
 
     case OPT_PRUNE:

--- a/libfswatch/src/libfswatch/c++/monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/monitor.cpp
@@ -190,6 +190,17 @@ namespace fsw
     }
   }
 
+  void monitor::set_filter_mode(fsw_filter_mode mode)
+  {
+    if (mode != fsw_filter_mode::filter_mode_legacy &&
+        mode != fsw_filter_mode::filter_mode_conjunctive)
+    {
+      throw libfsw_exception(_("Unknown filter mode."), FSW_ERR_UNKNOWN_VALUE);
+    }
+
+    filter_mode = mode;
+  }
+
   void monitor::set_follow_symlinks(bool follow)
   {
     follow_symlinks = follow;
@@ -214,6 +225,29 @@ namespace fsw
 
   bool monitor::accept_path(const std::string& path) const
   {
+    if (filter_mode == fsw_filter_mode::filter_mode_conjunctive)
+    {
+      bool has_includes = false;
+      bool included = false;
+
+      for (const auto& filter : filters)
+      {
+        const bool matches = std::regex_search(path, filter.regex);
+
+        if (filter.type == fsw_filter_type::filter_include)
+        {
+          has_includes = true;
+          included = included || matches;
+        }
+        else if (matches)
+        {
+          return false;
+        }
+      }
+
+      return !has_includes || included;
+    }
+
     bool is_excluded = false;
 
     for (const auto& filter : filters)

--- a/libfswatch/src/libfswatch/c++/monitor.hpp
+++ b/libfswatch/src/libfswatch/c++/monitor.hpp
@@ -311,6 +311,19 @@ namespace fsw
     void set_filters(const std::vector<monitor_filter>& filters);
 
     /**
+     * @brief Set the path filter evaluation mode.
+     *
+     * The default legacy mode accepts a path as soon as it matches an include
+     * filter, otherwise rejects it if it matches an exclude filter, otherwise
+     * accepts it.  Conjunctive mode accepts paths that match at least one
+     * include filter, or any path if no include filters exist, and then rejects
+     * paths that match any exclude filter.
+     *
+     * @param mode The path filter evaluation mode.
+     */
+    void set_filter_mode(fsw_filter_mode mode);
+
+    /**
      * @brief Add a traversal prune filter.
      *
      * This function adds a monitor_filter instance to the prune filter list.
@@ -657,6 +670,7 @@ namespace fsw
     std::vector<compiled_monitor_filter> filters;
     std::vector<std::regex> prune_filters;
     std::vector<fsw_event_type_filter> event_type_filters;
+    fsw_filter_mode filter_mode = fsw_filter_mode::filter_mode_legacy;
 
     static void inactivity_callback(monitor *mon);
     mutable std::atomic<std::chrono::milliseconds> last_notification;

--- a/libfswatch/src/libfswatch/c/cfilter.h
+++ b/libfswatch/src/libfswatch/c/cfilter.h
@@ -17,7 +17,7 @@
  * @file
  * @brief Header of the `libfswatch` library functions for filter management.
  *
- * @copyright Copyright (c) 2014-2016 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.8.0
@@ -39,6 +39,20 @@ extern "C"
   {
     filter_include,
     filter_exclude
+  };
+
+  /**
+   * @brief Path filter evaluation mode.
+   *
+   * filter_mode_legacy preserves the historical include-overrides-exclude
+   * behavior.  filter_mode_conjunctive accepts paths that match at least one
+   * inclusion filter, or all paths when no inclusion filters exist, and then
+   * rejects paths matching any exclusion filter.
+   */
+  enum fsw_filter_mode
+  {
+    filter_mode_legacy,
+    filter_mode_conjunctive
   };
 
   typedef struct fsw_cmonitor_filter

--- a/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -417,7 +417,8 @@
  * A _path filter_ (fsw::monitor_filter) can be used to filter event paths.  A
  * filter type (::fsw_filter_type) determines whether the filter regular
  * expression is used to include and exclude paths from the list of the events
- * processed by the library.  `libfswatch` processes filters this way:
+ * processed by the library.  By default, `libfswatch` uses the legacy filter
+ * mode and processes filters this way:
  *
  *   - If a path matches an including filter, the path is _accepted_ no matter
  *     any other filter.
@@ -434,6 +435,20 @@
  *   - Inclusion filters may override any other exclusion filter.
  *
  *   - The order in the filter definition has no effect.
+ *
+ * The filter mode can be set to ::filter_mode_conjunctive to evaluate filters
+ * as a conjunction:
+ *
+ *   - If no inclusion filters are specified, all paths are candidates.
+ *
+ *   - If at least one inclusion filter is specified, a path must match at
+ *     least one inclusion filter to be a candidate.
+ *
+ *   - Any matching exclusion filter rejects the path.
+ *
+ * Said another way, conjunctive mode accepts paths matching:
+ *
+ *   `(no includes OR matches include) AND NOT matches exclude`
  *
  * @section path-pruning Recursive Traversal Pruning
  *
@@ -481,6 +496,7 @@ using FSW_SESSION = struct FSW_SESSION
   bool recursive;
   bool directory_only;
   bool follow_symlinks;
+  fsw_filter_mode filter_mode;
   vector<monitor_filter> filters;
   vector<monitor_filter> prune_filters;
   vector<fsw_event_type_filter> event_type_filters;
@@ -823,6 +839,21 @@ FSW_STATUS fsw_add_filter(const FSW_HANDLE handle,
   return fsw_set_last_error(FSW_OK);
 }
 
+FSW_STATUS fsw_set_filter_mode(const FSW_HANDLE handle,
+                               const enum fsw_filter_mode mode)
+{
+  if (mode != fsw_filter_mode::filter_mode_legacy &&
+      mode != fsw_filter_mode::filter_mode_conjunctive)
+  {
+    return fsw_set_last_error(FSW_ERR_UNKNOWN_VALUE);
+  }
+
+  FSW_SESSION *session = get_session(handle);
+  session->filter_mode = mode;
+
+  return fsw_set_last_error(FSW_OK);
+}
+
 FSW_STATUS fsw_add_prune_filter(const FSW_HANDLE handle,
                                 const fsw_cmonitor_filter filter)
 {
@@ -864,6 +895,7 @@ FSW_STATUS fsw_start_monitor(const FSW_HANDLE handle)
       return fsw_set_last_error(int(FSW_ERR_MONITOR_ALREADY_RUNNING));
 
     session->monitor->set_allow_overflow(session->allow_overflow);
+    session->monitor->set_filter_mode(session->filter_mode);
     session->monitor->set_filters(session->filters);
     session->monitor->set_prune_filters(session->prune_filters);
     session->monitor->set_event_type_filters(session->event_type_filters);

--- a/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/libfswatch/src/libfswatch/c/libfswatch.h
@@ -183,6 +183,14 @@ extern "C"
                             const fsw_cmonitor_filter filter);
 
   /**
+   * Sets the path filter evaluation mode.  By default, libfswatch uses legacy
+   * include-overrides-exclude semantics.  See cfilter.h for the definition of
+   * fsw_filter_mode.
+   */
+  FSW_STATUS fsw_set_filter_mode(const FSW_HANDLE handle,
+                                 const enum fsw_filter_mode mode);
+
+  /**
    * Adds a prune filter to the current session.  A prune filter is a regular
    * expression that prevents recursive traversal from descending into matching
    * non-root directories.  It is not an event filter: pruned directories and

--- a/man/fswatch.7.in
+++ b/man/fswatch.7.in
@@ -117,6 +117,16 @@ Multiple exclude filters can be specified using this option multiple times.  See
 for further information.
 .It Fl E, -extended
 Use extended regular expressions.
+.It Fl -filter-mode Ar mode
+Set the path filter evaluation mode.
+.Ar mode
+can be
+.Ql legacy
+or
+.Ql conjunctive .
+See
+.Sx FILTERING PATHS
+for further information.
 .It Fl f, -format-time Ar format
 Print the event time using the specified
 .Ar format .
@@ -400,9 +410,17 @@ degradation that may result from frequent disk access.
 .El
 .Sh FILTERING PATHS
 Received events can be filtered by path using regular expressions.  Regular
-expressions can be used to include or exclude matching paths.  The user can
-specify multiple filter expression in any order and filters are processed this
-way:
+expressions can be used to include or exclude matching paths.
+.Nm
+supports two path filter evaluation modes:
+.Ql legacy
+and
+.Ql conjunctive .
+.Pp
+The default
+.Ql legacy
+mode preserves historical behavior.  The user can specify multiple filter
+expressions in any order and filters are processed this way:
 .Bl -tag -width indent
 .It -
 If a path matches an including filter, the path is accepted no matter
@@ -422,6 +440,31 @@ Inclusion filters may override any other exclusion filter.
 .It -
 The order in the definition of filters in the command line has no effect.
 .El
+.Pp
+The
+.Ql conjunctive
+mode is enabled with
+.Fl -filter-mode=conjunctive .
+It treats inclusion filters as the candidate set and exclusion filters as
+subtractions from that set:
+.Bl -tag -width indent
+.It -
+If no inclusion filters are specified, all paths are candidates.
+.It -
+If at least one inclusion filter is specified, a path must match an inclusion
+filter to be a candidate.
+.It -
+Any matching exclusion filter rejects the path.
+.El
+.Pp
+Said another way, conjunctive mode accepts paths matching this expression:
+.Pp
+.Dl (no includes OR matches include) AND NOT matches exclude
+.Pp
+For example, the following command reports changes to C source files except
+editor lock files:
+.Pp
+.Dl $ fswatch --filter-mode=conjunctive -i '\e.c$' -e '/lock-[^/]+\.c$' .
 
 .Ss Pruning Recursive Traversal
 The

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,7 +26,12 @@ TESTS =
 EXTRA_DIST =
 check_PROGRAMS =
 
+check_PROGRAMS += filter_mode_test
+filter_mode_test_SOURCES = src/filter_mode_test.cpp
+TESTS += filter_mode_test
+
 TESTS += poll_filter_root_path.sh
+TESTS += poll_filter_mode.sh
 TESTS += poll_prune.sh
 
 if USE_INOTIFY
@@ -47,6 +52,7 @@ if USE_INOTIFY
   TESTS += inotify_queue_drain.sh
   TESTS += inotify_recursive_create.sh
   TESTS += inotify_filter_root_path.sh
+  TESTS += inotify_filter_mode.sh
   TESTS += inotify_prune.sh
   TESTS += inotify_stop_latency_test
   TESTS += inotify_stop_with_pending_events_test
@@ -58,11 +64,13 @@ if USE_FANOTIFY
   TESTS += fanotify_access_events.sh
   TESTS += fanotify_unlimited_properties.sh
   TESTS += fanotify_filter_root_path.sh
+  TESTS += fanotify_filter_mode.sh
   TESTS += fanotify_prune.sh
 endif
 
 if USE_FSEVENTS
   TESTS += fsevents_filter_root_path.sh
+  TESTS += fsevents_filter_mode.sh
 endif
 
 EXTRA_DIST += inotify_basic_events.sh
@@ -74,14 +82,19 @@ EXTRA_DIST += inotify_burst_create.sh
 EXTRA_DIST += inotify_queue_drain.sh
 EXTRA_DIST += inotify_recursive_create.sh
 EXTRA_DIST += inotify_filter_root_path.sh
+EXTRA_DIST += inotify_filter_mode.sh
 EXTRA_DIST += inotify_prune.sh
 EXTRA_DIST += poll_filter_root_path.sh
+EXTRA_DIST += poll_filter_mode.sh
 EXTRA_DIST += poll_prune.sh
 EXTRA_DIST += filter_root_path.sh
+EXTRA_DIST += filter_mode.sh
 EXTRA_DIST += prune.sh
 EXTRA_DIST += fanotify_basic.sh
 EXTRA_DIST += fanotify_access_events.sh
 EXTRA_DIST += fanotify_unlimited_properties.sh
 EXTRA_DIST += fanotify_filter_root_path.sh
+EXTRA_DIST += fanotify_filter_mode.sh
 EXTRA_DIST += fanotify_prune.sh
 EXTRA_DIST += fsevents_filter_root_path.sh
+EXTRA_DIST += fsevents_filter_mode.sh

--- a/test/cmake/libfswatch_package_consumer.cmake
+++ b/test/cmake/libfswatch_package_consumer.cmake
@@ -93,6 +93,15 @@ string(APPEND consumer_main [=[
 
 int main()
 {
+  FSW_HANDLE handle = fsw_init_session(poll_monitor_type);
+  if (handle == nullptr) return 1;
+
+  if (fsw_set_filter_mode(handle, filter_mode_conjunctive) != FSW_OK)
+    return 1;
+
+  if (fsw_destroy_session(handle) != FSW_OK)
+    return 1;
+
   return fsw_init_library() == FSW_OK ? 0 : 1;
 }
 ]=])

--- a/test/fanotify_filter_mode.sh
+++ b/test/fanotify_filter_mode.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_mode.sh" "${1:-${FSWATCH:-}}" fanotify_monitor

--- a/test/filter_mode.sh
+++ b/test/filter_mode.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 2 ]; then
+  echo "usage: $0 [FSWATCH] [MONITOR]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+MONITOR=${2:-${MONITOR:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+if [ -z "${MONITOR}" ]; then
+  echo "MONITOR is required" >&2
+  exit 2
+fi
+if ! "${FSWATCH}" -M | grep -q "^  ${MONITOR}$"; then
+  echo "${MONITOR} is not built on this platform" >&2
+  exit 77
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-filter-mode.XXXXXX")
+PID=
+CHECK_PID=
+
+cleanup() {
+  if [ -n "${CHECK_PID}" ]; then
+    kill "${CHECK_PID}" 2>/dev/null || true
+    wait "${CHECK_PID}" 2>/dev/null || true
+  fi
+
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+check_fsevents_available() {
+  CHECKDIR="${WORKDIR}/fsevents-check"
+  mkdir "${CHECKDIR}"
+
+  "${FSWATCH}" -m "${MONITOR}" -r --format '%p %f' --event Created \
+    "${CHECKDIR}" > "${WORKDIR}/fsevents-check.out" 2> "${WORKDIR}/fsevents-check.err" &
+  CHECK_PID=$!
+
+  sleep 1
+  echo check > "${CHECKDIR}/check.txt"
+
+  found=
+  attempt=0
+  while [ "${attempt}" -lt 10 ]; do
+    if grep -Eq '/check\.txt .*Created' "${WORKDIR}/fsevents-check.out"; then
+      found=1
+      break
+    fi
+
+    if ! kill -0 "${CHECK_PID}" 2>/dev/null; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  kill "${CHECK_PID}" 2>/dev/null || true
+  wait "${CHECK_PID}" 2>/dev/null || true
+  CHECK_PID=
+
+  if [ -z "${found}" ]; then
+    echo "fsevents did not deliver a basic create event in this environment" >&2
+    sed -n '1,80p' "${WORKDIR}/fsevents-check.err" >&2
+    exit 77
+  fi
+}
+
+assert_event() {
+  pattern=$1
+  description=$2
+  output=$3
+  error=$4
+  found=
+  attempt=0
+
+  while [ "${attempt}" -lt 10 ]; do
+    if grep -Eq "${pattern}" "${output}"; then
+      found=1
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  if [ -z "${found}" ]; then
+    echo "missing ${description}" >&2
+    echo "--- fswatch output ---" >&2
+    sed -n '1,160p' "${output}" >&2
+    echo "--- fswatch stderr ---" >&2
+    sed -n '1,80p' "${error}" >&2
+    exit 1
+  fi
+}
+
+assert_no_event() {
+  pattern=$1
+  description=$2
+  output=$3
+  error=$4
+
+  sleep 1
+
+  if grep -Eq "${pattern}" "${output}"; then
+    echo "unexpected ${description}" >&2
+    echo "--- fswatch output ---" >&2
+    sed -n '1,160p' "${output}" >&2
+    echo "--- fswatch stderr ---" >&2
+    sed -n '1,80p' "${error}" >&2
+    exit 1
+  fi
+}
+
+start_fswatch() {
+  output=$1
+  error=$2
+  shift 2
+
+  "${FSWATCH}" -m "${MONITOR}" -r --format '%p %f' --event Created \
+    "$@" > "${output}" 2> "${error}" &
+  PID=$!
+
+  sleep 1
+
+  if ! kill -0 "${PID}" 2>/dev/null; then
+    if [ "${MONITOR}" = "fanotify_monitor" ] &&
+       grep -Eqi 'fanotify|permission|operation not permitted|not supported|Cannot initialize' "${error}"; then
+      echo "fanotify is unavailable in this environment" >&2
+      sed -n '1,120p' "${error}" >&2
+      exit 77
+    fi
+
+    echo "${MONITOR} exited unexpectedly" >&2
+    sed -n '1,120p' "${error}" >&2
+    exit 1
+  fi
+}
+
+stop_fswatch() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+    PID=
+  fi
+}
+
+run_case() {
+  name=$1
+  shift
+  TESTDIR="${WORKDIR}/${name}"
+  mkdir "${TESTDIR}"
+  OUT="${WORKDIR}/${name}.out"
+  ERR="${WORKDIR}/${name}.err"
+
+  start_fswatch "${OUT}" "${ERR}" "$@" "${TESTDIR}"
+
+  echo keep > "${TESTDIR}/keep.c"
+  echo skip > "${TESTDIR}/skip.c"
+  echo other > "${TESTDIR}/other.txt"
+
+  assert_event '/keep\.c .*Created' "${name}: included event" "${OUT}" "${ERR}"
+}
+
+if [ "${MONITOR}" = "fsevents_monitor" ]; then
+  check_fsevents_available
+fi
+
+if "${FSWATCH}" --filter-mode=invalid "${WORKDIR}" > "${WORKDIR}/invalid.out" 2> "${WORKDIR}/invalid.err"; then
+  echo "invalid filter mode was accepted" >&2
+  exit 1
+fi
+if ! grep -Eq 'Invalid filter mode' "${WORKDIR}/invalid.err"; then
+  echo "invalid filter mode did not explain the error" >&2
+  sed -n '1,80p' "${WORKDIR}/invalid.err" >&2
+  exit 1
+fi
+
+run_case legacy -e '.*' -i '\.c$' -e '/skip\.c$'
+assert_event '/skip\.c .*Created' 'legacy include overrides exclude' "${OUT}" "${ERR}"
+assert_no_event '/other\.txt .*Created' 'legacy excluded unmatched event' "${OUT}" "${ERR}"
+stop_fswatch
+
+run_case conjunctive --filter-mode=conjunctive -i '\.c$' -e '/skip\.c$'
+assert_no_event '/skip\.c .*Created' 'conjunctive excluded included event' "${OUT}" "${ERR}"
+assert_no_event '/other\.txt .*Created' 'conjunctive unmatched event' "${OUT}" "${ERR}"
+stop_fswatch
+
+run_case include-only --filter-mode=conjunctive -i '\.c$'
+assert_event '/skip\.c .*Created' 'conjunctive included event' "${OUT}" "${ERR}"
+assert_no_event '/other\.txt .*Created' 'conjunctive include-only unmatched event' "${OUT}" "${ERR}"
+stop_fswatch
+
+run_case exclude-only --filter-mode=conjunctive -e '/skip\.c$'
+assert_no_event '/skip\.c .*Created' 'conjunctive exclude-only event' "${OUT}" "${ERR}"
+assert_event '/other\.txt .*Created' 'conjunctive exclude-only unmatched event' "${OUT}" "${ERR}"
+stop_fswatch

--- a/test/fsevents_filter_mode.sh
+++ b/test/fsevents_filter_mode.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_mode.sh" "${1:-${FSWATCH:-}}" fsevents_monitor

--- a/test/inotify_filter_mode.sh
+++ b/test/inotify_filter_mode.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_mode.sh" "${1:-${FSWATCH:-}}" inotify_monitor

--- a/test/poll_filter_mode.sh
+++ b/test/poll_filter_mode.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_mode.sh" "${1:-${FSWATCH:-}}" poll_monitor

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -26,6 +26,14 @@ if (BUILD_TESTING)
     find_program(SH_EXECUTABLE sh)
     find_program(GIT_EXECUTABLE git)
 
+    add_executable(filter_mode_test filter_mode_test.cpp)
+    target_include_directories(filter_mode_test PRIVATE ../.. .)
+    target_include_directories(filter_mode_test BEFORE PRIVATE ${PROJECT_BINARY_DIR})
+    target_link_libraries(filter_mode_test PUBLIC libfswatch)
+    add_test(NAME filter_mode_test COMMAND filter_mode_test)
+    set_tests_properties(filter_mode_test PROPERTIES
+            LABELS "unit;filtering")
+
     if (HAVE_INOTIFY_MONITOR)
         add_executable(inotify_stop_latency_test inotify_stop_latency_test.cpp)
         target_include_directories(inotify_stop_latency_test PRIVATE ../.. .)
@@ -120,6 +128,15 @@ if (BUILD_TESTING)
                     LABELS "integration;inotify;filtering"
                     TIMEOUT 15)
 
+            add_test(NAME inotify_filter_mode
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/filter_mode.sh
+                            $<TARGET_FILE:fswatch>
+                            inotify_monitor)
+            set_tests_properties(inotify_filter_mode PROPERTIES
+                    LABELS "integration;inotify;filtering"
+                    TIMEOUT 20)
+
             add_test(NAME inotify_prune
                     COMMAND ${SH_EXECUTABLE}
                             ${PROJECT_SOURCE_DIR}/test/prune.sh
@@ -152,6 +169,15 @@ if (BUILD_TESTING)
         set_tests_properties(poll_filter_root_path PROPERTIES
                 LABELS "integration;poll;filtering"
                 TIMEOUT 20)
+
+        add_test(NAME poll_filter_mode
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/filter_mode.sh
+                        $<TARGET_FILE:fswatch>
+                        poll_monitor)
+        set_tests_properties(poll_filter_mode PROPERTIES
+                LABELS "integration;poll;filtering"
+                TIMEOUT 25)
 
         add_test(NAME poll_prune
                 COMMAND ${SH_EXECUTABLE}
@@ -201,6 +227,16 @@ if (BUILD_TESTING)
                 SKIP_RETURN_CODE 77
                 TIMEOUT 20)
 
+        add_test(NAME fanotify_filter_mode
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/filter_mode.sh
+                        $<TARGET_FILE:fswatch>
+                        fanotify_monitor)
+        set_tests_properties(fanotify_filter_mode PROPERTIES
+                LABELS "integration;fanotify;filtering"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 25)
+
         add_test(NAME fanotify_prune
                 COMMAND ${SH_EXECUTABLE}
                         ${PROJECT_SOURCE_DIR}/test/prune.sh
@@ -237,6 +273,16 @@ if (BUILD_TESTING)
                     LABELS "integration;fsevents;filtering"
                     SKIP_RETURN_CODE 77
                     TIMEOUT 20)
+
+            add_test(NAME fsevents_filter_mode
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/filter_mode.sh
+                            $<TARGET_FILE:fswatch>
+                            fsevents_monitor)
+            set_tests_properties(fsevents_filter_mode PROPERTIES
+                    LABELS "integration;fsevents;filtering"
+                    SKIP_RETURN_CODE 77
+                    TIMEOUT 25)
         endif ()
     endif ()
 endif ()

--- a/test/src/filter_mode_test.cpp
+++ b/test/src/filter_mode_test.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <libfswatch/c++/event.hpp>
+#include <libfswatch/c++/libfswatch_exception.hpp>
+#include <libfswatch/c++/monitor.hpp>
+#include <libfswatch/c/error.h>
+#include <libfswatch/c/libfswatch.h>
+
+using namespace fsw;
+
+namespace
+{
+  void test_callback(const std::vector<event>&, void *)
+  {
+  }
+
+  class test_monitor : public monitor
+  {
+  public:
+    test_monitor() : monitor({"."}, test_callback)
+    {
+    }
+
+    bool accepts(const std::string& path) const
+    {
+      return accept_path(path);
+    }
+
+  private:
+    void run() override
+    {
+    }
+  };
+
+  bool expect(bool condition, const char *message)
+  {
+    if (condition) return true;
+
+    std::cerr << message << "\n";
+    return false;
+  }
+
+  monitor_filter include(const std::string& pattern)
+  {
+    return {pattern, fsw_filter_type::filter_include, true, false};
+  }
+
+  monitor_filter exclude(const std::string& pattern)
+  {
+    return {pattern, fsw_filter_type::filter_exclude, true, false};
+  }
+}
+
+int main()
+{
+  bool ok = true;
+
+  test_monitor legacy;
+  legacy.add_filter(exclude(".*"));
+  legacy.add_filter(include("\\.c$"));
+  legacy.add_filter(exclude("/skip\\.c$"));
+
+  ok = expect(legacy.accepts("/tmp/keep.c"),
+              "legacy mode rejected an included path") && ok;
+  ok = expect(legacy.accepts("/tmp/skip.c"),
+              "legacy mode did not let include override exclude") && ok;
+  ok = expect(!legacy.accepts("/tmp/other.txt"),
+              "legacy mode accepted an excluded unmatched path") && ok;
+
+  test_monitor conjunctive;
+  conjunctive.set_filter_mode(fsw_filter_mode::filter_mode_conjunctive);
+  conjunctive.add_filter(include("\\.c$"));
+  conjunctive.add_filter(exclude("/skip\\.c$"));
+
+  ok = expect(conjunctive.accepts("/tmp/keep.c"),
+              "conjunctive mode rejected an included path") && ok;
+  ok = expect(!conjunctive.accepts("/tmp/skip.c"),
+              "conjunctive mode did not subtract an excluded included path") &&
+       ok;
+  ok = expect(!conjunctive.accepts("/tmp/other.txt"),
+              "conjunctive mode accepted an excluded unmatched path") && ok;
+
+  test_monitor include_only;
+  include_only.set_filter_mode(fsw_filter_mode::filter_mode_conjunctive);
+  include_only.add_filter(include("\\.c$"));
+
+  ok = expect(include_only.accepts("/tmp/keep.c"),
+              "conjunctive include-only mode rejected a matching path") && ok;
+  ok = expect(!include_only.accepts("/tmp/other.txt"),
+              "conjunctive include-only mode accepted a nonmatching path") &&
+       ok;
+
+  test_monitor exclude_only;
+  exclude_only.set_filter_mode(fsw_filter_mode::filter_mode_conjunctive);
+  exclude_only.add_filter(exclude("/skip\\.c$"));
+
+  ok = expect(exclude_only.accepts("/tmp/keep.c"),
+              "conjunctive exclude-only mode rejected an unmatched path") && ok;
+  ok = expect(!exclude_only.accepts("/tmp/skip.c"),
+              "conjunctive exclude-only mode accepted a matching path") && ok;
+
+  try
+  {
+    test_monitor invalid;
+    invalid.set_filter_mode(static_cast<fsw_filter_mode>(-1));
+    ok = expect(false, "invalid filter mode was accepted") && ok;
+  }
+  catch (const libfsw_exception& ex)
+  {
+    ok = expect(static_cast<int>(ex) == FSW_ERR_UNKNOWN_VALUE,
+                "invalid filter mode reported the wrong error") && ok;
+  }
+
+  FSW_HANDLE handle = fsw_init_session(fsw_monitor_type::poll_monitor_type);
+  ok = expect(handle != nullptr, "C API session could not be created") && ok;
+  if (handle != nullptr)
+  {
+    ok = expect(fsw_set_filter_mode(
+                  handle,
+                  fsw_filter_mode::filter_mode_conjunctive) == FSW_OK,
+                "C API rejected conjunctive filter mode") && ok;
+    ok = expect(fsw_set_filter_mode(
+                  handle,
+                  static_cast<fsw_filter_mode>(-1)) == FSW_ERR_UNKNOWN_VALUE,
+                "C API accepted invalid filter mode") && ok;
+    ok = expect(fsw_destroy_session(handle) == FSW_OK,
+                "C API session could not be destroyed") && ok;
+  }
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds an opt-in conjunctive path filter mode for fswatch and libfswatch.

In the new mode, inclusion filters define the candidate set and exclusion filters subtract from it:

```text
accepted = (no includes OR matches include) AND NOT matches exclude
```

The existing include-overrides-exclude behavior remains the default legacy mode, so existing CLI and library callers keep their current behavior unless they explicitly opt in.

Closes #104.
Closes #273.

## Changes

- Add `--filter-mode=legacy|conjunctive` to the CLI.
- Add `fsw_filter_mode`, `fsw_set_filter_mode()`, and `monitor::set_filter_mode()` to libfswatch.
- Document legacy and conjunctive filter semantics in the man page and Texinfo manual.
- Update README and NEWS files.
- Add C/C++ unit coverage, CLI integration coverage, and CMake package consumer coverage.

## Validation

- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `make`
- `make check`

FSEvents filtering integration tests skipped in this environment because the basic FSEvents create-event probe did not deliver an event.
