### PR TITLE
Harden filtering release coverage

### DIFF
--- a/fswatch/doc/fswatch.texi
+++ b/fswatch/doc/fswatch.texi
@@ -1143,14 +1143,12 @@ It is of type @command{NoOp}.
 @cpindex path filter
 @cpindex path filter, inclusion
 @cpindex path filter, exclusion
-Filters are @emph{regular expression} which are evaluated against the
-monitored object path to determine whether a path must be accepted or
-rejected.  Sometimes, the exclusion of a path may result in the
-exclusion of an object from the list of monitored objects, while other
-times a path must be evaluated only when an event is detected and in
-this case the corresponding object cannot be removed from the
-monitored object list in advance@footnote{This behaviour is
-monitor-specific.}.
+Filters are @emph{regular expression} which are evaluated against
+event paths to determine whether matching events are reported.
+Explicit command-line root paths remain eligible for monitor setup
+even when an output filter would reject the root path itself.  Use
+@option{--prune} when the intended effect is to avoid descending into
+matching directories during recursive traversal.
 
 Event though event @emph{filtering} is commonly performed when
 processing @command{fswatch} output, the possibility of filtering
@@ -1249,7 +1247,9 @@ Two types of filters are available:
 @end itemize
 
 As their name indicates, they are used to include and exclude paths
-from the monitored object list and from resulting events.
+from reported events.  Explicit command-line root paths remain eligible
+for monitor setup even when an output filter would reject the root path
+itself.
 @command{fswatch} supports two path filter evaluation modes:
 @samp{legacy} and @samp{conjunctive}.
 
@@ -1321,9 +1321,13 @@ $ fswatch --filter-mode=conjunctive -i '\.c$' -e '/lock-[^/]+\.c$' .
 The @option{--prune} option defines regular expressions that stop
 recursive traversal from descending into matching directories.  This is
 different from @option{--exclude}: excluded paths are filtered from
-the resulting events, while pruned directories and their descendants
-are not scanned or monitored by recursive monitors that traverse
-directory trees.
+reported events, while pruned directories and their descendants are
+skipped during library-side recursive traversal.
+
+Pruning only affects monitors that perform this traversal in
+@command{fswatch}.  Native recursive backends may accept
+@option{--prune}, but may not be able to prevent the operating system
+from traversing matching subtrees in the same way.
 
 Prune expressions use the same case-sensitivity and extended-regular
 expression settings as normal path filters.

--- a/libfswatch/src/libfswatch/c++/fen_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/fen_monitor.cpp
@@ -278,7 +278,7 @@ namespace fsw
       if (should_prune_path(path.string(), is_dir, is_root_path)) return true;
 
       if (!is_dir && !is_root_path && directory_only) return true;
-      if (!is_dir && !accept_path(path)) return true;
+      if (!is_dir && !is_root_path && !accept_path(path)) return true;
       if (!is_dir) return add_watch(path, fd_stat);
       if (!recursive) return true;
 

--- a/man/fswatch.7.in
+++ b/man/fswatch.7.in
@@ -458,6 +458,9 @@ degradation that may result from frequent disk access.
 .Sh FILTERING PATHS
 Received events can be filtered by path using regular expressions.  Regular
 expressions can be used to include or exclude matching paths.
+.Pp
+Explicit command-line root paths remain eligible for monitor setup even when an
+output filter would reject the root path itself.
 .Nm
 supports two path filter evaluation modes:
 .Ql legacy

--- a/man/fswatch.7.in
+++ b/man/fswatch.7.in
@@ -480,7 +480,9 @@ If a path matches no filters, the path is accepted.
 Said another way:
 .Bl -tag -width indent
 .It -
-All paths are accepted @emph{by default}, unless an exclusion filter
+All paths are accepted
+.Em by default ,
+unless an exclusion filter
 says otherwise.
 .It -
 Inclusion filters may override any other exclusion filter.
@@ -519,9 +521,15 @@ The
 option defines regular expressions that stop recursive traversal from
 descending into matching directories.  This is different from
 .Fl -exclude :
-excluded paths are filtered from the resulting events, while pruned directories
-and their descendants are not scanned or monitored by recursive monitors that
-traverse directory trees.
+excluded paths are filtered from reported events, while pruned directories
+and their descendants are skipped during library-side recursive traversal.
+.Pp
+Pruning only affects monitors that perform this traversal in
+.Nm .
+Native recursive backends may accept
+.Fl -prune ,
+but may not be able to prevent the operating system from traversing matching
+subtrees in the same way.
 .Pp
 Prune expressions use the same case-sensitivity and extended-regular-expression
 settings as normal path filters.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,9 +30,15 @@ check_PROGRAMS += filter_mode_test
 filter_mode_test_SOURCES = src/filter_mode_test.cpp
 TESTS += filter_mode_test
 
+check_PROGRAMS += prune_c_api_test
+prune_c_api_test_SOURCES = src/prune_c_api_test.cpp
+TESTS += prune_c_api_test
+
 TESTS += poll_filter_root_path.sh
+TESTS += poll_filter_root_file.sh
 TESTS += poll_filter_mode.sh
 TESTS += poll_prune.sh
+TESTS += poll_prune_root_path.sh
 
 if USE_INOTIFY
   check_PROGRAMS += inotify_stop_latency_test
@@ -52,8 +58,10 @@ if USE_INOTIFY
   TESTS += inotify_queue_drain.sh
   TESTS += inotify_recursive_create.sh
   TESTS += inotify_filter_root_path.sh
+  TESTS += inotify_filter_root_file.sh
   TESTS += inotify_filter_mode.sh
   TESTS += inotify_prune.sh
+  TESTS += inotify_prune_root_path.sh
   TESTS += inotify_stop_latency_test
   TESTS += inotify_stop_with_pending_events_test
   TESTS += inotify_stop_with_ready_events_test
@@ -66,6 +74,15 @@ if USE_FANOTIFY
   TESTS += fanotify_filter_root_path.sh
   TESTS += fanotify_filter_mode.sh
   TESTS += fanotify_prune.sh
+  TESTS += fanotify_prune_root_path.sh
+endif
+
+if USE_FEN
+  TESTS += fen_filter_root_file.sh
+endif
+
+if USE_KQUEUE
+  TESTS += kqueue_filter_root_file.sh
 endif
 
 if USE_FSEVENTS
@@ -82,19 +99,28 @@ EXTRA_DIST += inotify_burst_create.sh
 EXTRA_DIST += inotify_queue_drain.sh
 EXTRA_DIST += inotify_recursive_create.sh
 EXTRA_DIST += inotify_filter_root_path.sh
+EXTRA_DIST += inotify_filter_root_file.sh
 EXTRA_DIST += inotify_filter_mode.sh
 EXTRA_DIST += inotify_prune.sh
+EXTRA_DIST += inotify_prune_root_path.sh
 EXTRA_DIST += poll_filter_root_path.sh
+EXTRA_DIST += poll_filter_root_file.sh
 EXTRA_DIST += poll_filter_mode.sh
 EXTRA_DIST += poll_prune.sh
+EXTRA_DIST += poll_prune_root_path.sh
 EXTRA_DIST += filter_root_path.sh
+EXTRA_DIST += filter_root_file.sh
 EXTRA_DIST += filter_mode.sh
 EXTRA_DIST += prune.sh
+EXTRA_DIST += prune_root_path.sh
 EXTRA_DIST += fanotify_basic.sh
 EXTRA_DIST += fanotify_access_events.sh
 EXTRA_DIST += fanotify_unlimited_properties.sh
 EXTRA_DIST += fanotify_filter_root_path.sh
 EXTRA_DIST += fanotify_filter_mode.sh
 EXTRA_DIST += fanotify_prune.sh
+EXTRA_DIST += fanotify_prune_root_path.sh
+EXTRA_DIST += fen_filter_root_file.sh
+EXTRA_DIST += kqueue_filter_root_file.sh
 EXTRA_DIST += fsevents_filter_root_path.sh
 EXTRA_DIST += fsevents_filter_mode.sh

--- a/test/fanotify_prune_root_path.sh
+++ b/test/fanotify_prune_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/prune_root_path.sh" "${1:-${FSWATCH:-}}" fanotify_monitor

--- a/test/fen_filter_root_file.sh
+++ b/test/fen_filter_root_file.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [FSWATCH]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+if ! "${FSWATCH}" -M | grep -q '^  fen_monitor$'; then
+  echo "fen_monitor is not built on this platform" >&2
+  exit 77
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-fen-filter-root-file.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+ROOT_FILE="${WORKDIR}/filtered-root-file.txt"
+echo initial > "${ROOT_FILE}"
+
+"${FSWATCH}" -m fen_monitor -v -e '.*' "${ROOT_FILE}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+found=
+attempt=0
+while [ "${attempt}" -lt 10 ]; do
+  if grep -Fq "Adding ${ROOT_FILE} to list of watched paths." "${WORKDIR}/err.log"; then
+    found=1
+    break
+  fi
+
+  if ! kill -0 "${PID}" 2>/dev/null; then
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "FEN did not add filtered command-line root file to its watch list" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,160p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/filter_root_file.sh
+++ b/test/filter_root_file.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 2 ]; then
+  echo "usage: $0 [FSWATCH] [MONITOR]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+MONITOR=${2:-${MONITOR:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+if [ -z "${MONITOR}" ]; then
+  echo "MONITOR is required" >&2
+  exit 2
+fi
+if ! "${FSWATCH}" -M | grep -q "^  ${MONITOR}$"; then
+  echo "${MONITOR} is not built on this platform" >&2
+  exit 77
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-filter-root-file.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+ROOT_FILE="${WORKDIR}/watched-file.keep"
+echo initial > "${ROOT_FILE}"
+
+"${FSWATCH}" -m "${MONITOR}" --format '%p %f' \
+  --event Updated --event CloseWrite \
+  -e '.*' -i '/watched-file\.keep$' "${ROOT_FILE}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+if ! kill -0 "${PID}" 2>/dev/null; then
+  if [ "${MONITOR}" = "fanotify_monitor" ] &&
+     grep -Eqi 'fanotify|permission|operation not permitted|not supported|Cannot initialize' "${WORKDIR}/err.log"; then
+    echo "fanotify is unavailable in this environment" >&2
+    sed -n '1,120p' "${WORKDIR}/err.log" >&2
+    exit 77
+  fi
+
+  echo "${MONITOR} exited unexpectedly" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi
+
+found=
+attempt=0
+while [ "${attempt}" -lt 10 ]; do
+  echo update >> "${ROOT_FILE}"
+
+  if grep -Eq '/watched-file\.keep .*(Updated|CloseWrite)' "${WORKDIR}/out.log"; then
+    found=1
+    break
+  fi
+
+  if ! kill -0 "${PID}" 2>/dev/null; then
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "missing event for filtered command-line root file" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/inotify_filter_root_file.sh
+++ b/test/inotify_filter_root_file.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_file.sh" "${1:-${FSWATCH:-}}" inotify_monitor

--- a/test/inotify_prune_root_path.sh
+++ b/test/inotify_prune_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/prune_root_path.sh" "${1:-${FSWATCH:-}}" inotify_monitor

--- a/test/kqueue_filter_root_file.sh
+++ b/test/kqueue_filter_root_file.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_file.sh" "${1:-${FSWATCH:-}}" kqueue_monitor

--- a/test/poll_filter_root_file.sh
+++ b/test/poll_filter_root_file.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/filter_root_file.sh" "${1:-${FSWATCH:-}}" poll_monitor

--- a/test/poll_prune_root_path.sh
+++ b/test/poll_prune_root_path.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "${SCRIPT_DIR}/prune_root_path.sh" "${1:-${FSWATCH:-}}" poll_monitor

--- a/test/prune_root_path.sh
+++ b/test/prune_root_path.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+#
+# Copyright (c) 2026 Enrico M. Crisostomo
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eu
+
+if [ "$#" -gt 2 ]; then
+  echo "usage: $0 [FSWATCH] [MONITOR]" >&2
+  exit 2
+fi
+
+FSWATCH=${1:-${FSWATCH:-}}
+MONITOR=${2:-${MONITOR:-}}
+if [ -z "${FSWATCH}" ]; then
+  echo "FSWATCH is required" >&2
+  exit 2
+fi
+if [ -z "${MONITOR}" ]; then
+  echo "MONITOR is required" >&2
+  exit 2
+fi
+if ! "${FSWATCH}" -M | grep -q "^  ${MONITOR}$"; then
+  echo "${MONITOR} is not built on this platform" >&2
+  exit 77
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+WORKDIR=$(mktemp -d "${TMPDIR%/}/fswatch-prune-root.XXXXXX")
+PID=
+
+cleanup() {
+  if [ -n "${PID}" ]; then
+    kill "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+  fi
+
+  rm -rf "${WORKDIR}"
+}
+
+trap cleanup EXIT INT TERM
+
+ROOT="${WORKDIR}/pruned"
+CHILD_PRUNED="${ROOT}/pruned"
+VISIBLE="${ROOT}/visible"
+
+mkdir -p "${CHILD_PRUNED}" "${VISIBLE}"
+
+"${FSWATCH}" -m "${MONITOR}" -r --format '%p %f' --event Created \
+  --prune '/pruned$' "${ROOT}" \
+  > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
+PID=$!
+
+sleep 1
+
+if ! kill -0 "${PID}" 2>/dev/null; then
+  if [ "${MONITOR}" = "fanotify_monitor" ] &&
+     grep -Eqi 'fanotify|permission|operation not permitted|not supported|Cannot initialize' "${WORKDIR}/err.log"; then
+    echo "fanotify is unavailable in this environment" >&2
+    sed -n '1,120p' "${WORKDIR}/err.log" >&2
+    exit 77
+  fi
+
+  echo "${MONITOR} exited unexpectedly" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi
+
+echo visible > "${VISIBLE}/visible.txt"
+echo hidden > "${CHILD_PRUNED}/hidden.txt"
+
+found=
+attempt=0
+while [ "${attempt}" -lt 10 ]; do
+  if grep -Eq '/visible/visible\.txt .*Created' "${WORKDIR}/out.log"; then
+    found=1
+    break
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+if [ -z "${found}" ]; then
+  echo "missing event below command-line root matching prune filter" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi
+
+sleep 1
+
+if grep -Eq '/pruned/pruned/hidden\.txt' "${WORKDIR}/out.log"; then
+  echo "event below non-root pruned directory was reported" >&2
+  echo "--- fswatch output ---" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  echo "--- fswatch stderr ---" >&2
+  sed -n '1,120p' "${WORKDIR}/err.log" >&2
+  exit 1
+fi

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -34,6 +34,15 @@ if (BUILD_TESTING)
     set_tests_properties(filter_mode_test PROPERTIES
             LABELS "unit;filtering")
 
+    add_executable(prune_c_api_test prune_c_api_test.cpp)
+    target_include_directories(prune_c_api_test PRIVATE ../.. .)
+    target_include_directories(prune_c_api_test BEFORE PRIVATE ${PROJECT_BINARY_DIR})
+    target_link_libraries(prune_c_api_test PUBLIC libfswatch)
+    add_test(NAME prune_c_api_test COMMAND prune_c_api_test)
+    set_tests_properties(prune_c_api_test PROPERTIES
+            LABELS "integration;poll;filtering"
+            TIMEOUT 15)
+
     if (HAVE_INOTIFY_MONITOR)
         add_executable(inotify_stop_latency_test inotify_stop_latency_test.cpp)
         target_include_directories(inotify_stop_latency_test PRIVATE ../.. .)
@@ -128,6 +137,15 @@ if (BUILD_TESTING)
                     LABELS "integration;inotify;filtering"
                     TIMEOUT 15)
 
+            add_test(NAME inotify_filter_root_file
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/filter_root_file.sh
+                            $<TARGET_FILE:fswatch>
+                            inotify_monitor)
+            set_tests_properties(inotify_filter_root_file PROPERTIES
+                    LABELS "integration;inotify;filtering"
+                    TIMEOUT 15)
+
             add_test(NAME inotify_filter_mode
                     COMMAND ${SH_EXECUTABLE}
                             ${PROJECT_SOURCE_DIR}/test/filter_mode.sh
@@ -143,6 +161,15 @@ if (BUILD_TESTING)
                             $<TARGET_FILE:fswatch>
                             inotify_monitor)
             set_tests_properties(inotify_prune PROPERTIES
+                    LABELS "integration;inotify;filtering"
+                    TIMEOUT 15)
+
+            add_test(NAME inotify_prune_root_path
+                    COMMAND ${SH_EXECUTABLE}
+                            ${PROJECT_SOURCE_DIR}/test/prune_root_path.sh
+                            $<TARGET_FILE:fswatch>
+                            inotify_monitor)
+            set_tests_properties(inotify_prune_root_path PROPERTIES
                     LABELS "integration;inotify;filtering"
                     TIMEOUT 15)
 
@@ -170,6 +197,15 @@ if (BUILD_TESTING)
                 LABELS "integration;poll;filtering"
                 TIMEOUT 20)
 
+        add_test(NAME poll_filter_root_file
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/filter_root_file.sh
+                        $<TARGET_FILE:fswatch>
+                        poll_monitor)
+        set_tests_properties(poll_filter_root_file PROPERTIES
+                LABELS "integration;poll;filtering"
+                TIMEOUT 20)
+
         add_test(NAME poll_filter_mode
                 COMMAND ${SH_EXECUTABLE}
                         ${PROJECT_SOURCE_DIR}/test/filter_mode.sh
@@ -185,6 +221,15 @@ if (BUILD_TESTING)
                         $<TARGET_FILE:fswatch>
                         poll_monitor)
         set_tests_properties(poll_prune PROPERTIES
+                LABELS "integration;poll;filtering"
+                TIMEOUT 20)
+
+        add_test(NAME poll_prune_root_path
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/prune_root_path.sh
+                        $<TARGET_FILE:fswatch>
+                        poll_monitor)
+        set_tests_properties(poll_prune_root_path PROPERTIES
                 LABELS "integration;poll;filtering"
                 TIMEOUT 20)
     endif ()
@@ -244,6 +289,39 @@ if (BUILD_TESTING)
                         fanotify_monitor)
         set_tests_properties(fanotify_prune PROPERTIES
                 LABELS "integration;fanotify;filtering"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
+
+        add_test(NAME fanotify_prune_root_path
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/prune_root_path.sh
+                        $<TARGET_FILE:fswatch>
+                        fanotify_monitor)
+        set_tests_properties(fanotify_prune_root_path PROPERTIES
+                LABELS "integration;fanotify;filtering"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
+    endif ()
+
+    if (SH_EXECUTABLE AND HAVE_PORT_H)
+        add_test(NAME fen_filter_root_file
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/fen_filter_root_file.sh
+                        $<TARGET_FILE:fswatch>)
+        set_tests_properties(fen_filter_root_file PROPERTIES
+                LABELS "integration;fen;filtering"
+                SKIP_RETURN_CODE 77
+                TIMEOUT 20)
+    endif ()
+
+    if (SH_EXECUTABLE AND HAVE_SYS_EVENT_H)
+        add_test(NAME kqueue_filter_root_file
+                COMMAND ${SH_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/filter_root_file.sh
+                        $<TARGET_FILE:fswatch>
+                        kqueue_monitor)
+        set_tests_properties(kqueue_filter_root_file PROPERTIES
+                LABELS "integration;kqueue;filtering"
                 SKIP_RETURN_CODE 77
                 TIMEOUT 20)
     endif ()

--- a/test/src/prune_c_api_test.cpp
+++ b/test/src/prune_c_api_test.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <libfswatch/c/libfswatch.h>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+  struct callback_context
+  {
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::vector<std::string> paths;
+  };
+
+  void callback(fsw_cevent const *const events,
+                const unsigned int event_num,
+                void *data)
+  {
+    auto *context = static_cast<callback_context *>(data);
+
+    {
+      std::lock_guard<std::mutex> guard(context->mutex);
+      for (unsigned int i = 0; i < event_num; ++i)
+      {
+        context->paths.emplace_back(events[i].path);
+      }
+    }
+
+    context->condition.notify_all();
+  }
+
+  bool expect_ok(FSW_STATUS status, const char *message)
+  {
+    if (status == FSW_OK) return true;
+
+    std::cerr << message << ": " << fsw_last_error() << "\n";
+    return false;
+  }
+
+  bool has_path_containing(const callback_context& context,
+                           const std::string& needle)
+  {
+    for (const auto& path : context.paths)
+    {
+      if (path.find(needle) != std::string::npos) return true;
+    }
+
+    return false;
+  }
+}
+
+int main()
+{
+  namespace fs = std::filesystem;
+  using namespace std::chrono_literals;
+
+  if (!expect_ok(fsw_init_library(), "fsw_init_library failed")) return 1;
+
+  const fs::path test_dir =
+    fs::temp_directory_path() /
+    ("fswatch-prune-c-api-" +
+     std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  const fs::path pruned_dir = test_dir / "pruned";
+  const fs::path visible_dir = test_dir / "visible";
+
+  fs::create_directories(pruned_dir);
+  fs::create_directories(visible_dir);
+
+  FSW_HANDLE handle = fsw_init_session(poll_monitor_type);
+  if (!handle)
+  {
+    std::cerr << "fsw_init_session failed\n";
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  callback_context context;
+  char prune_pattern[] = "/pruned$";
+  fsw_cmonitor_filter prune_filter = {
+    prune_pattern,
+    fsw_filter_type::filter_exclude,
+    true,
+    false,
+  };
+
+  bool ok =
+    expect_ok(fsw_add_path(handle, test_dir.string().c_str()), "fsw_add_path failed") &&
+    expect_ok(fsw_set_recursive(handle, true), "fsw_set_recursive failed") &&
+    expect_ok(fsw_set_callback(handle, callback, &context), "fsw_set_callback failed") &&
+    expect_ok(fsw_set_latency(handle, 1.0), "fsw_set_latency failed") &&
+    expect_ok(fsw_add_prune_filter(handle, prune_filter), "fsw_add_prune_filter failed");
+
+  if (!ok)
+  {
+    fsw_destroy_session(handle);
+    fs::remove_all(test_dir);
+    return 1;
+  }
+
+  auto monitor_status = std::async(std::launch::async, [handle] {
+    return fsw_start_monitor(handle);
+  });
+
+  std::this_thread::sleep_for(1500ms);
+
+  {
+    std::ofstream visible_file(visible_dir / "visible.txt");
+    visible_file << "visible\n";
+
+    std::ofstream hidden_file(pruned_dir / "hidden.txt");
+    hidden_file << "hidden\n";
+  }
+
+  {
+    std::unique_lock<std::mutex> guard(context.mutex);
+    context.condition.wait_for(guard, 6s, [&context] {
+      return has_path_containing(context, "/visible/visible.txt");
+    });
+  }
+
+  if (!expect_ok(fsw_stop_monitor(handle), "fsw_stop_monitor failed"))
+  {
+    std::quick_exit(1);
+  }
+
+  if (monitor_status.wait_for(3s) != std::future_status::ready)
+  {
+    std::cerr << "poll monitor did not stop promptly\n";
+    std::quick_exit(2);
+  }
+
+  ok = expect_ok(monitor_status.get(), "fsw_start_monitor failed") && ok;
+
+  {
+    std::lock_guard<std::mutex> guard(context.mutex);
+    ok = (has_path_containing(context, "/visible/visible.txt") ||
+          (std::cerr << "missing event outside pruned directory\n", false)) && ok;
+    ok = (!has_path_containing(context, "/pruned/hidden.txt") ||
+          (std::cerr << "event below pruned directory was reported\n", false)) && ok;
+  }
+
+  ok = expect_ok(fsw_destroy_session(handle), "fsw_destroy_session failed") && ok;
+
+  fs::remove_all(test_dir);
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- add regression coverage for filter root eligibility across poll, inotify, kqueue, and FEN paths
- add prune root-path and C API regression coverage
- clarify filter root eligibility and traversal pruning documentation
- fix FEN root-file filter eligibility during monitor setup

## Compatibility and behavior

This keeps legacy filter behavior as the default. The documentation clarifies that path filters govern emitted events, while prune filters govern recursive traversal where the selected monitor performs library-side traversal.

## Validation

Not run in this publishing step; branch contains focused regression tests for the filtering and pruning behavior.