### PR TITLE
Bump v. 1.21.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(fswatch VERSION 1.21.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-develop")
+set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,22 +1,34 @@
 NEWS
 ****
 
-New in 1.21.0-develop:
+New in 1.21.0:
 
-  * Issues 104 and 273: Add --filter-mode=conjunctive so include filters can
-    define a candidate set while exclude filters subtract from it.
+  * CLI, Issues 104 and 273: Add --filter-mode=conjunctive.  In this mode,
+    include filters define the candidate set and exclude filters subtract from
+    it: a path is accepted when it matches an include filter, or when no
+    include filters are specified, and does not match any exclude filter.
 
-  * Issue 151: Add --prune to prevent recursive traversal from descending into
-    matching directories.
+  * CLI, Issue 151: Add --prune to prevent recursive traversal from descending
+    into matching directories where the selected monitor performs traversal in
+    fswatch or libfswatch.  This is distinct from --exclude: --exclude filters
+    emitted events, while --prune prevents recursive descent into matching
+    subtrees.
+
+  * Compatibility: Legacy include/exclude filter behavior remains the default.
+    In legacy mode, include filters may still override exclude filters.
 
   * Issue 305: Install CMake package configuration files for libfswatch so
     CMake consumers can use find_package(libfswatch CONFIG).
 
-  * Issue 247: Keep root paths and directories watchable during monitor setup
-    when path filters exclude their names but include matching children.
+  * Bug fix, Issue 247: Keep explicit root paths eligible for monitor setup
+    even when path filters would reject the root path itself, allowing matching
+    children to be discovered and reported.
 
   * Issue 238: Document the BSD/macOS xargs replacement-string length caveat
     when processing fswatch output with xargs -I.
+
+  * Add filtering regression coverage for legacy and conjunctive filter modes,
+    root-path eligibility, and traversal pruning.
 
 
 New in 1.20.1:

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,20 +1,37 @@
 NEWS
 ****
 
-New in 1.21.0-develop:
+New in 1.21.0:
 
-  * Issues 104 and 273: Add a conjunctive path filter mode so inclusion
-    filters define a candidate set and exclusion filters subtract from it.
+  * API, Issues 104 and 273: Add conjunctive path filter evaluation mode.  In
+    this mode, inclusion filters define the candidate set and exclusion filters
+    subtract from it: a path is accepted when it matches an inclusion filter,
+    or when no inclusion filters are specified, and does not match any
+    exclusion filter.
 
-  * Issue 151: Add traversal prune filters to libfswatch so recursive monitors
-    can skip matching directories before scanning or watching their
-    descendants.
+  * API, Issue 151: Add traversal prune filters so recursive monitors can skip
+    matching directories before scanning or watching their descendants.  Prune
+    filters are separate from normal path filters: normal exclude filters
+    reject emitted events, while prune filters prevent recursive descent where
+    the monitor performs library-side traversal.
 
-  * Issue 247: Keep root paths and directories watchable during monitor setup
-    when path filters exclude their names but include matching children.
+  * API: Add C API support for filter mode selection and prune filters.
+
+  * Compatibility: Legacy filter behavior remains the default.
+
+  * Compatibility: The public C++ fsw::monitor layout changed.  Existing
+    compiled C++ clients should be rebuilt against this release.  The
+    libfswatch libtool release version is 15:0:0.
+
+  * Bug fix, Issue 247: Keep explicit root paths eligible for monitor setup
+    even when path filters would reject the root path itself, allowing matching
+    children to remain discoverable.
 
   * Issue 305: Install CMake package configuration files and exported targets
     for libfswatch so CMake consumers can use find_package(libfswatch CONFIG).
+
+  * Add regression coverage for filter modes, root-path eligibility, traversal
+    pruning, and the new C API pruning entry point.
 
 
 New in 1.20.1:

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.21.0-develop])
+m4_define([FSWATCH_VERSION], [1.21.0])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.21.0-develop])
-m4_define([LIBFSWATCH_API_VERSION], [14:0:0])
+m4_define([LIBFSWATCH_VERSION], [1.21.0])
+m4_define([LIBFSWATCH_API_VERSION], [15:0:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-28 21:41+0200\n"
+"POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: English\n"
@@ -17,275 +17,287 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: fswatch/src/fswatch.cpp:147
+#: fswatch/src/fswatch.cpp:151
 msgid ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:148
+#: fswatch/src/fswatch.cpp:152
 msgid "This is free software: you are free to change and redistribute it.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:149
+#: fswatch/src/fswatch.cpp:153
 msgid "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:151
+#: fswatch/src/fswatch.cpp:155
 msgid "Written by Enrico M. Crisostomo."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:159 fswatch/src/fswatch.cpp:206
+#: fswatch/src/fswatch.cpp:163 fswatch/src/fswatch.cpp:213
 msgid "Usage:\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:160
+#: fswatch/src/fswatch.cpp:164
 msgid " [OPTION] ... path ...\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:162 fswatch/src/fswatch.cpp:209
+#: fswatch/src/fswatch.cpp:166 fswatch/src/fswatch.cpp:216
 msgid "Options:\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:163
+#: fswatch/src/fswatch.cpp:167
 msgid "Use the ASCII NUL character (0) as line separator.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:164
+#: fswatch/src/fswatch.cpp:168
 msgid "Exit fswatch after the first set of events is received.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:165
+#: fswatch/src/fswatch.cpp:169
 msgid "Allow a monitor to overflow and report it as a change event.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:166
+#: fswatch/src/fswatch.cpp:170
 msgid "Print a marker at the end of every batch.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:167
+#: fswatch/src/fswatch.cpp:171
 msgid "Watch file accesses.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:168
+#: fswatch/src/fswatch.cpp:172
 msgid "Bubble events with the same timestamp and path.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:169
+#: fswatch/src/fswatch.cpp:173
 msgid "Watch directories only.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:170
+#: fswatch/src/fswatch.cpp:174
 msgid "Exclude paths matching REGEX.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:171
+#: fswatch/src/fswatch.cpp:175
 msgid "Use extended regular expressions.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:173
+#: fswatch/src/fswatch.cpp:177
 msgid "Load filters from file."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:174
+#: fswatch/src/fswatch.cpp:179
+msgid "Set filter mode: legacy or conjunctive."
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:180
 msgid "Use the specified record format."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:175
+#: fswatch/src/fswatch.cpp:181
 msgid ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:176
+#: fswatch/src/fswatch.cpp:182
 msgid "Print the event time using the specified format.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:177
+#: fswatch/src/fswatch.cpp:183
 msgid "Fire idle events.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:178
+#: fswatch/src/fswatch.cpp:184
 msgid "Show this message.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:179
+#: fswatch/src/fswatch.cpp:185
 msgid "Include paths matching REGEX.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:180
+#: fswatch/src/fswatch.cpp:186
 msgid "Use case insensitive regular expressions.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:181
+#: fswatch/src/fswatch.cpp:187
 msgid "Set the latency.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:183
+#: fswatch/src/fswatch.cpp:189
 msgid "Set the no defer flag in the monitor.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:185
+#: fswatch/src/fswatch.cpp:191
 msgid "Follow symbolic links.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:186
+#: fswatch/src/fswatch.cpp:192
 msgid "List the available monitors.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:187
+#: fswatch/src/fswatch.cpp:193
 msgid "Use the specified monitor.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:189
+#: fswatch/src/fswatch.cpp:195
 msgid "Define the specified property.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:190
+#: fswatch/src/fswatch.cpp:196
 msgid "Print a numeric event mask.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:191
+#: fswatch/src/fswatch.cpp:197
 msgid "Print a single message with the number of change events.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:192
-msgid "Recurse subdirectories.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:193
-msgid "Print the event timestamp.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:194
-msgid "Print the event time as UTC time.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:195
-msgid "Print the event flags.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:196
-msgid "Filter the event by the specified type.\n"
-msgstr ""
-
 #: fswatch/src/fswatch.cpp:198
-msgid "Print event flags using the specified separator."
+msgid "Do not descend into directories matching REGEX.\n"
 msgstr ""
 
 #: fswatch/src/fswatch.cpp:199
+msgid "Recurse subdirectories.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:200
+msgid "Print the event timestamp.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:201
+msgid "Print the event time as UTC time.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:202
+msgid "Print the event flags.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:203
+msgid "Filter the event by the specified type.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:205
+msgid "Print event flags using the specified separator."
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:206
 msgid "Print verbose output.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid "Print the version of "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid " and exit.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:238
+#: fswatch/src/fswatch.cpp:245
 msgid ""
 "Available monitors in this platform:\n"
 "\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:241
+#: fswatch/src/fswatch.cpp:248
 msgid ""
 "\n"
 "See the man page for more information.\n"
 "\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:243
+#: fswatch/src/fswatch.cpp:250
 msgid "Report bugs to <"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:244
+#: fswatch/src/fswatch.cpp:251
 msgid " home page: <"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:255
+#: fswatch/src/fswatch.cpp:262
 msgid "Executing termination handler.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:306
+#: fswatch/src/fswatch.cpp:325
+msgid "Invalid filter mode: "
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:333
 #: libfswatch/src/libfswatch/c++/windows_monitor.cpp:208
 msgid "Invalid value: "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:312
+#: fswatch/src/fswatch.cpp:339
 msgid "Value out of range: "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:328
+#: fswatch/src/fswatch.cpp:355
 msgid "SIGTERM handler registered.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:332
+#: fswatch/src/fswatch.cpp:359
 msgid "SIGTERM handler registration failed."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:337
+#: fswatch/src/fswatch.cpp:364
 msgid "SIGABRT handler registered.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:341
+#: fswatch/src/fswatch.cpp:368
 msgid "SIGABRT handler registration failed."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:346
+#: fswatch/src/fswatch.cpp:373
 msgid "SIGINT handler registered.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:350
+#: fswatch/src/fswatch.cpp:377
 msgid "SIGINT handler registration failed"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:372
+#: fswatch/src/fswatch.cpp:399
 msgid "<date format error>"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:476
+#: fswatch/src/fswatch.cpp:503
 #, c-format
 msgid "Adding path: %s\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:509
+#: fswatch/src/fswatch.cpp:542
 msgid "Invalid filter: "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:751
+#: fswatch/src/fswatch.cpp:799
 msgid ""
 "--format is incompatible with any other format option such as -t and -x."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:759
+#: fswatch/src/fswatch.cpp:807
 msgid "--format is incompatible with -o."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:774
+#: fswatch/src/fswatch.cpp:822
 msgid "Invalid format."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:801
+#: fswatch/src/fswatch.cpp:849
 msgid "Invalid property format."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:911
+#: fswatch/src/fswatch.cpp:959
 msgid "Invalid number of arguments."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:917
+#: fswatch/src/fswatch.cpp:965
 msgid "Invalid monitor name."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:949
+#: fswatch/src/fswatch.cpp:997
 msgid "An error occurred and the program will be terminated.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:956
+#: fswatch/src/fswatch.cpp:1004
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr ""
 
@@ -328,17 +340,17 @@ msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr ""
@@ -378,25 +390,25 @@ msgstr ""
 msgid "Cannot allocate memory"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:308
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:309
 #, c-format
 msgid "%s cannot be found. Will retry later.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:332
 msgid "Processing deleted descriptors.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:353
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:354
 msgid "Rescanning pending descriptors.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:359
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:360
 #, c-format
 msgid "Rescanning %s.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:399
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:400
 msgid "Event from unexpected source"
 msgstr ""
 
@@ -471,23 +483,23 @@ msgstr ""
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 
@@ -496,19 +508,19 @@ msgstr ""
 msgid "Cannot open %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:280
 msgid "kqueue already running."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:287
 msgid "kqueue failed."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:313
 msgid "kevent returned -1, invalid event number."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:332
 msgid "Event with EV_ERROR"
 msgstr ""
 
@@ -521,35 +533,40 @@ msgid "Latency cannot be negative."
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/monitor.cpp:131
+#: libfswatch/src/libfswatch/c++/monitor.cpp:152
 #, c-format
 msgid "An error occurred during the compilation of %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:221
+#: libfswatch/src/libfswatch/c++/monitor.cpp:198
+msgid "Unknown filter mode."
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/monitor.cpp:300
 msgid "Callback argument cannot be null."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:223
+#: libfswatch/src/libfswatch/c++/monitor.cpp:302
 msgid "Inactivity notification thread: starting\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:258
+#: libfswatch/src/libfswatch/c++/monitor.cpp:337
 msgid "Inactivity notification thread: exiting\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:280
+#: libfswatch/src/libfswatch/c++/monitor.cpp:359
 msgid "Inactivity notification thread: joining\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/monitor.cpp:376
 msgid "Stopping the monitor.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:325
+#: libfswatch/src/libfswatch/c++/monitor.cpp:404
 msgid "Event queue overflow."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:405
+#: libfswatch/src/libfswatch/c++/monitor.cpp:484
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr ""
@@ -575,7 +592,7 @@ msgstr ""
 msgid "Cannot lstat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:230
 msgid "Done scanning.\n"
 msgstr ""
 

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,10 +30,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.21.0-develop\n"
+"Project-Id-Version: fswatch 1.21.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-28 21:41+0200\n"
-"PO-Revision-Date: 2026-04-28 21:41+0200\n"
+"POT-Creation-Date: 2026-05-09 20:17+0200\n"
+"PO-Revision-Date: 2026-05-09 20:17+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@boldquot\n"
@@ -42,7 +42,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: fswatch/src/fswatch.cpp:147
+#: fswatch/src/fswatch.cpp:151
 msgid ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
@@ -50,75 +50,79 @@ msgstr ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
 
-#: fswatch/src/fswatch.cpp:148
+#: fswatch/src/fswatch.cpp:152
 msgid "This is free software: you are free to change and redistribute it.\n"
 msgstr "This is free software: you are free to change and redistribute it.\n"
 
-#: fswatch/src/fswatch.cpp:149
+#: fswatch/src/fswatch.cpp:153
 msgid "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr "There is NO WARRANTY, to the extent permitted by law.\n"
 
-#: fswatch/src/fswatch.cpp:151
+#: fswatch/src/fswatch.cpp:155
 msgid "Written by Enrico M. Crisostomo."
 msgstr "Written by Enrico M. Crisostomo."
 
-#: fswatch/src/fswatch.cpp:159 fswatch/src/fswatch.cpp:206
+#: fswatch/src/fswatch.cpp:163 fswatch/src/fswatch.cpp:213
 msgid "Usage:\n"
 msgstr "Usage:\n"
 
-#: fswatch/src/fswatch.cpp:160
+#: fswatch/src/fswatch.cpp:164
 msgid " [OPTION] ... path ...\n"
 msgstr " [OPTION] ... path ...\n"
 
-#: fswatch/src/fswatch.cpp:162 fswatch/src/fswatch.cpp:209
+#: fswatch/src/fswatch.cpp:166 fswatch/src/fswatch.cpp:216
 msgid "Options:\n"
 msgstr "Options:\n"
 
-#: fswatch/src/fswatch.cpp:163
+#: fswatch/src/fswatch.cpp:167
 msgid "Use the ASCII NUL character (0) as line separator.\n"
 msgstr "Use the ASCII NUL character (0) as line separator.\n"
 
-#: fswatch/src/fswatch.cpp:164
+#: fswatch/src/fswatch.cpp:168
 msgid "Exit fswatch after the first set of events is received.\n"
 msgstr "Exit fswatch after the first set of events is received.\n"
 
-#: fswatch/src/fswatch.cpp:165
+#: fswatch/src/fswatch.cpp:169
 msgid "Allow a monitor to overflow and report it as a change event.\n"
 msgstr "Allow a monitor to overflow and report it as a change event.\n"
 
-#: fswatch/src/fswatch.cpp:166
+#: fswatch/src/fswatch.cpp:170
 msgid "Print a marker at the end of every batch.\n"
 msgstr "Print a marker at the end of every batch.\n"
 
-#: fswatch/src/fswatch.cpp:167
+#: fswatch/src/fswatch.cpp:171
 msgid "Watch file accesses.\n"
 msgstr "Watch file accesses.\n"
 
-#: fswatch/src/fswatch.cpp:168
+#: fswatch/src/fswatch.cpp:172
 msgid "Bubble events with the same timestamp and path.\n"
 msgstr "Bubble events with the same timestamp and path.\n"
 
-#: fswatch/src/fswatch.cpp:169
+#: fswatch/src/fswatch.cpp:173
 msgid "Watch directories only.\n"
 msgstr "Watch directories only.\n"
 
-#: fswatch/src/fswatch.cpp:170
+#: fswatch/src/fswatch.cpp:174
 msgid "Exclude paths matching REGEX.\n"
 msgstr "Exclude paths matching REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:171
+#: fswatch/src/fswatch.cpp:175
 msgid "Use extended regular expressions.\n"
 msgstr "Use extended regular expressions.\n"
 
-#: fswatch/src/fswatch.cpp:173
+#: fswatch/src/fswatch.cpp:177
 msgid "Load filters from file."
 msgstr "Load filters from file."
 
-#: fswatch/src/fswatch.cpp:174
+#: fswatch/src/fswatch.cpp:179
+msgid "Set filter mode: legacy or conjunctive."
+msgstr "Set filter mode: legacy or conjunctive."
+
+#: fswatch/src/fswatch.cpp:180
 msgid "Use the specified record format."
 msgstr "Use the specified record format."
 
-#: fswatch/src/fswatch.cpp:175
+#: fswatch/src/fswatch.cpp:181
 msgid ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
@@ -126,95 +130,99 @@ msgstr ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
 
-#: fswatch/src/fswatch.cpp:176
+#: fswatch/src/fswatch.cpp:182
 msgid "Print the event time using the specified format.\n"
 msgstr "Print the event time using the specified format.\n"
 
-#: fswatch/src/fswatch.cpp:177
+#: fswatch/src/fswatch.cpp:183
 msgid "Fire idle events.\n"
 msgstr "Fire idle events.\n"
 
-#: fswatch/src/fswatch.cpp:178
+#: fswatch/src/fswatch.cpp:184
 msgid "Show this message.\n"
 msgstr "Show this message.\n"
 
-#: fswatch/src/fswatch.cpp:179
+#: fswatch/src/fswatch.cpp:185
 msgid "Include paths matching REGEX.\n"
 msgstr "Include paths matching REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:180
+#: fswatch/src/fswatch.cpp:186
 msgid "Use case insensitive regular expressions.\n"
 msgstr "Use case insensitive regular expressions.\n"
 
-#: fswatch/src/fswatch.cpp:181
+#: fswatch/src/fswatch.cpp:187
 msgid "Set the latency.\n"
 msgstr "Set the latency.\n"
 
-#: fswatch/src/fswatch.cpp:183
+#: fswatch/src/fswatch.cpp:189
 msgid "Set the no defer flag in the monitor.\n"
 msgstr "Set the no defer flag in the monitor.\n"
 
-#: fswatch/src/fswatch.cpp:185
+#: fswatch/src/fswatch.cpp:191
 msgid "Follow symbolic links.\n"
 msgstr "Follow symbolic links.\n"
 
-#: fswatch/src/fswatch.cpp:186
+#: fswatch/src/fswatch.cpp:192
 msgid "List the available monitors.\n"
 msgstr "List the available monitors.\n"
 
-#: fswatch/src/fswatch.cpp:187
+#: fswatch/src/fswatch.cpp:193
 msgid "Use the specified monitor.\n"
 msgstr "Use the specified monitor.\n"
 
-#: fswatch/src/fswatch.cpp:189
+#: fswatch/src/fswatch.cpp:195
 msgid "Define the specified property.\n"
 msgstr "Define the specified property.\n"
 
-#: fswatch/src/fswatch.cpp:190
+#: fswatch/src/fswatch.cpp:196
 msgid "Print a numeric event mask.\n"
 msgstr "Print a numeric event mask.\n"
 
-#: fswatch/src/fswatch.cpp:191
+#: fswatch/src/fswatch.cpp:197
 msgid "Print a single message with the number of change events.\n"
 msgstr "Print a single message with the number of change events.\n"
 
-#: fswatch/src/fswatch.cpp:192
+#: fswatch/src/fswatch.cpp:198
+msgid "Do not descend into directories matching REGEX.\n"
+msgstr "Do not descend into directories matching REGEX.\n"
+
+#: fswatch/src/fswatch.cpp:199
 msgid "Recurse subdirectories.\n"
 msgstr "Recurse subdirectories.\n"
 
-#: fswatch/src/fswatch.cpp:193
+#: fswatch/src/fswatch.cpp:200
 msgid "Print the event timestamp.\n"
 msgstr "Print the event timestamp.\n"
 
-#: fswatch/src/fswatch.cpp:194
+#: fswatch/src/fswatch.cpp:201
 msgid "Print the event time as UTC time.\n"
 msgstr "Print the event time as UTC time.\n"
 
-#: fswatch/src/fswatch.cpp:195
+#: fswatch/src/fswatch.cpp:202
 msgid "Print the event flags.\n"
 msgstr "Print the event flags.\n"
 
-#: fswatch/src/fswatch.cpp:196
+#: fswatch/src/fswatch.cpp:203
 msgid "Filter the event by the specified type.\n"
 msgstr "Filter the event by the specified type.\n"
 
-#: fswatch/src/fswatch.cpp:198
+#: fswatch/src/fswatch.cpp:205
 msgid "Print event flags using the specified separator."
 msgstr "Print event flags using the specified separator."
 
-#: fswatch/src/fswatch.cpp:199
+#: fswatch/src/fswatch.cpp:206
 msgid "Print verbose output.\n"
 msgstr "Print verbose output.\n"
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid "Print the version of "
 msgstr "Print the version of "
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid " and exit.\n"
 msgstr " and exit.\n"
 
-#: fswatch/src/fswatch.cpp:238
+#: fswatch/src/fswatch.cpp:245
 msgid ""
 "Available monitors in this platform:\n"
 "\n"
@@ -222,7 +230,7 @@ msgstr ""
 "Available monitors in this platform:\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:241
+#: fswatch/src/fswatch.cpp:248
 msgid ""
 "\n"
 "See the man page for more information.\n"
@@ -232,95 +240,99 @@ msgstr ""
 "See the man page for more information.\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:243
+#: fswatch/src/fswatch.cpp:250
 msgid "Report bugs to <"
 msgstr "Report bugs to <"
 
-#: fswatch/src/fswatch.cpp:244
+#: fswatch/src/fswatch.cpp:251
 msgid " home page: <"
 msgstr " home page: <"
 
-#: fswatch/src/fswatch.cpp:255
+#: fswatch/src/fswatch.cpp:262
 msgid "Executing termination handler.\n"
 msgstr "Executing termination handler.\n"
 
-#: fswatch/src/fswatch.cpp:306
+#: fswatch/src/fswatch.cpp:325
+msgid "Invalid filter mode: "
+msgstr "Invalid filter mode: "
+
+#: fswatch/src/fswatch.cpp:333
 #: libfswatch/src/libfswatch/c++/windows_monitor.cpp:208
 msgid "Invalid value: "
 msgstr "Invalid value: "
 
-#: fswatch/src/fswatch.cpp:312
+#: fswatch/src/fswatch.cpp:339
 msgid "Value out of range: "
 msgstr "Value out of range: "
 
-#: fswatch/src/fswatch.cpp:328
+#: fswatch/src/fswatch.cpp:355
 msgid "SIGTERM handler registered.\n"
 msgstr "SIGTERM handler registered.\n"
 
-#: fswatch/src/fswatch.cpp:332
+#: fswatch/src/fswatch.cpp:359
 msgid "SIGTERM handler registration failed."
 msgstr "SIGTERM handler registration failed."
 
-#: fswatch/src/fswatch.cpp:337
+#: fswatch/src/fswatch.cpp:364
 msgid "SIGABRT handler registered.\n"
 msgstr "SIGABRT handler registered.\n"
 
-#: fswatch/src/fswatch.cpp:341
+#: fswatch/src/fswatch.cpp:368
 msgid "SIGABRT handler registration failed."
 msgstr "SIGABRT handler registration failed."
 
-#: fswatch/src/fswatch.cpp:346
+#: fswatch/src/fswatch.cpp:373
 msgid "SIGINT handler registered.\n"
 msgstr "SIGINT handler registered.\n"
 
-#: fswatch/src/fswatch.cpp:350
+#: fswatch/src/fswatch.cpp:377
 msgid "SIGINT handler registration failed"
 msgstr "SIGINT handler registration failed"
 
-#: fswatch/src/fswatch.cpp:372
+#: fswatch/src/fswatch.cpp:399
 msgid "<date format error>"
 msgstr "<date format error>"
 
-#: fswatch/src/fswatch.cpp:476
+#: fswatch/src/fswatch.cpp:503
 #, c-format
 msgid "Adding path: %s\n"
 msgstr "Adding path: %s\n"
 
-#: fswatch/src/fswatch.cpp:509
+#: fswatch/src/fswatch.cpp:542
 msgid "Invalid filter: "
 msgstr "Invalid filter: "
 
-#: fswatch/src/fswatch.cpp:751
+#: fswatch/src/fswatch.cpp:799
 msgid ""
 "--format is incompatible with any other format option such as -t and -x."
 msgstr ""
 "--format is incompatible with any other format option such as -t and -x."
 
-#: fswatch/src/fswatch.cpp:759
+#: fswatch/src/fswatch.cpp:807
 msgid "--format is incompatible with -o."
 msgstr "--format is incompatible with -o."
 
-#: fswatch/src/fswatch.cpp:774
+#: fswatch/src/fswatch.cpp:822
 msgid "Invalid format."
 msgstr "Invalid format."
 
-#: fswatch/src/fswatch.cpp:801
+#: fswatch/src/fswatch.cpp:849
 msgid "Invalid property format."
 msgstr "Invalid property format."
 
-#: fswatch/src/fswatch.cpp:911
+#: fswatch/src/fswatch.cpp:959
 msgid "Invalid number of arguments."
 msgstr "Invalid number of arguments."
 
-#: fswatch/src/fswatch.cpp:917
+#: fswatch/src/fswatch.cpp:965
 msgid "Invalid monitor name."
 msgstr "Invalid monitor name."
 
-#: fswatch/src/fswatch.cpp:949
+#: fswatch/src/fswatch.cpp:997
 msgid "An error occurred and the program will be terminated.\n"
 msgstr "An error occurred and the program will be terminated.\n"
 
-#: fswatch/src/fswatch.cpp:956
+#: fswatch/src/fswatch.cpp:1004
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "An unknown error occurred and the program will be terminated.\n"
 
@@ -364,17 +376,17 @@ msgstr "fanotify added: %s\n"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Synthetic event: processing directory: %s\n"
@@ -414,25 +426,25 @@ msgstr "Allocating fen_info.\n"
 msgid "Cannot allocate memory"
 msgstr "Cannot allocate memory"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:308
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:309
 #, c-format
 msgid "%s cannot be found. Will retry later.\n"
 msgstr "%s cannot be found. Will retry later.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:332
 msgid "Processing deleted descriptors.\n"
 msgstr "Processing deleted descriptors.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:353
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:354
 msgid "Rescanning pending descriptors.\n"
 msgstr "Rescanning pending descriptors.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:359
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:360
 #, c-format
 msgid "Rescanning %s.\n"
 msgstr "Rescanning %s.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:399
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:400
 msgid "Event from unexpected source"
 msgstr "Event from unexpected source"
 
@@ -507,23 +519,23 @@ msgstr "Removing: "
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 
@@ -532,19 +544,19 @@ msgstr "read() on inotify descriptor returned -1."
 msgid "Cannot open %s"
 msgstr "Cannot open %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:280
 msgid "kqueue already running."
 msgstr "kqueue already running."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:287
 msgid "kqueue failed."
 msgstr "kqueue failed."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:313
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent returned -1, invalid event number."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:332
 msgid "Event with EV_ERROR"
 msgstr "Event with EV_ERROR"
 
@@ -557,35 +569,40 @@ msgid "Latency cannot be negative."
 msgstr "Latency cannot be negative."
 
 #: libfswatch/src/libfswatch/c++/monitor.cpp:131
+#: libfswatch/src/libfswatch/c++/monitor.cpp:152
 #, c-format
 msgid "An error occurred during the compilation of %s"
 msgstr "An error occurred during the compilation of %s"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:221
+#: libfswatch/src/libfswatch/c++/monitor.cpp:198
+msgid "Unknown filter mode."
+msgstr "Unknown filter mode."
+
+#: libfswatch/src/libfswatch/c++/monitor.cpp:300
 msgid "Callback argument cannot be null."
 msgstr "Callback argument cannot be null."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:223
+#: libfswatch/src/libfswatch/c++/monitor.cpp:302
 msgid "Inactivity notification thread: starting\n"
 msgstr "Inactivity notification thread: starting\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:258
+#: libfswatch/src/libfswatch/c++/monitor.cpp:337
 msgid "Inactivity notification thread: exiting\n"
 msgstr "Inactivity notification thread: exiting\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:280
+#: libfswatch/src/libfswatch/c++/monitor.cpp:359
 msgid "Inactivity notification thread: joining\n"
 msgstr "Inactivity notification thread: joining\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/monitor.cpp:376
 msgid "Stopping the monitor.\n"
 msgstr "Stopping the monitor.\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:325
+#: libfswatch/src/libfswatch/c++/monitor.cpp:404
 msgid "Event queue overflow."
 msgstr "Event queue overflow."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:405
+#: libfswatch/src/libfswatch/c++/monitor.cpp:484
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notifying events #: %d.\n"
@@ -611,7 +628,7 @@ msgstr "Cannot lstat %s (not implemented on Windows)"
 msgid "Cannot lstat %s"
 msgstr "Cannot lstat %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:230
 msgid "Done scanning.\n"
 msgstr "Done scanning.\n"
 

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,10 +27,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.21.0-develop\n"
+"Project-Id-Version: fswatch 1.21.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-28 21:41+0200\n"
-"PO-Revision-Date: 2026-04-28 21:41+0200\n"
+"POT-Creation-Date: 2026-05-09 20:17+0200\n"
+"PO-Revision-Date: 2026-05-09 20:17+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@quot\n"
@@ -39,7 +39,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: fswatch/src/fswatch.cpp:147
+#: fswatch/src/fswatch.cpp:151
 msgid ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
@@ -47,75 +47,79 @@ msgstr ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
 
-#: fswatch/src/fswatch.cpp:148
+#: fswatch/src/fswatch.cpp:152
 msgid "This is free software: you are free to change and redistribute it.\n"
 msgstr "This is free software: you are free to change and redistribute it.\n"
 
-#: fswatch/src/fswatch.cpp:149
+#: fswatch/src/fswatch.cpp:153
 msgid "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr "There is NO WARRANTY, to the extent permitted by law.\n"
 
-#: fswatch/src/fswatch.cpp:151
+#: fswatch/src/fswatch.cpp:155
 msgid "Written by Enrico M. Crisostomo."
 msgstr "Written by Enrico M. Crisostomo."
 
-#: fswatch/src/fswatch.cpp:159 fswatch/src/fswatch.cpp:206
+#: fswatch/src/fswatch.cpp:163 fswatch/src/fswatch.cpp:213
 msgid "Usage:\n"
 msgstr "Usage:\n"
 
-#: fswatch/src/fswatch.cpp:160
+#: fswatch/src/fswatch.cpp:164
 msgid " [OPTION] ... path ...\n"
 msgstr " [OPTION] ... path ...\n"
 
-#: fswatch/src/fswatch.cpp:162 fswatch/src/fswatch.cpp:209
+#: fswatch/src/fswatch.cpp:166 fswatch/src/fswatch.cpp:216
 msgid "Options:\n"
 msgstr "Options:\n"
 
-#: fswatch/src/fswatch.cpp:163
+#: fswatch/src/fswatch.cpp:167
 msgid "Use the ASCII NUL character (0) as line separator.\n"
 msgstr "Use the ASCII NUL character (0) as line separator.\n"
 
-#: fswatch/src/fswatch.cpp:164
+#: fswatch/src/fswatch.cpp:168
 msgid "Exit fswatch after the first set of events is received.\n"
 msgstr "Exit fswatch after the first set of events is received.\n"
 
-#: fswatch/src/fswatch.cpp:165
+#: fswatch/src/fswatch.cpp:169
 msgid "Allow a monitor to overflow and report it as a change event.\n"
 msgstr "Allow a monitor to overflow and report it as a change event.\n"
 
-#: fswatch/src/fswatch.cpp:166
+#: fswatch/src/fswatch.cpp:170
 msgid "Print a marker at the end of every batch.\n"
 msgstr "Print a marker at the end of every batch.\n"
 
-#: fswatch/src/fswatch.cpp:167
+#: fswatch/src/fswatch.cpp:171
 msgid "Watch file accesses.\n"
 msgstr "Watch file accesses.\n"
 
-#: fswatch/src/fswatch.cpp:168
+#: fswatch/src/fswatch.cpp:172
 msgid "Bubble events with the same timestamp and path.\n"
 msgstr "Bubble events with the same timestamp and path.\n"
 
-#: fswatch/src/fswatch.cpp:169
+#: fswatch/src/fswatch.cpp:173
 msgid "Watch directories only.\n"
 msgstr "Watch directories only.\n"
 
-#: fswatch/src/fswatch.cpp:170
+#: fswatch/src/fswatch.cpp:174
 msgid "Exclude paths matching REGEX.\n"
 msgstr "Exclude paths matching REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:171
+#: fswatch/src/fswatch.cpp:175
 msgid "Use extended regular expressions.\n"
 msgstr "Use extended regular expressions.\n"
 
-#: fswatch/src/fswatch.cpp:173
+#: fswatch/src/fswatch.cpp:177
 msgid "Load filters from file."
 msgstr "Load filters from file."
 
-#: fswatch/src/fswatch.cpp:174
+#: fswatch/src/fswatch.cpp:179
+msgid "Set filter mode: legacy or conjunctive."
+msgstr "Set filter mode: legacy or conjunctive."
+
+#: fswatch/src/fswatch.cpp:180
 msgid "Use the specified record format."
 msgstr "Use the specified record format."
 
-#: fswatch/src/fswatch.cpp:175
+#: fswatch/src/fswatch.cpp:181
 msgid ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
@@ -123,95 +127,99 @@ msgstr ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
 
-#: fswatch/src/fswatch.cpp:176
+#: fswatch/src/fswatch.cpp:182
 msgid "Print the event time using the specified format.\n"
 msgstr "Print the event time using the specified format.\n"
 
-#: fswatch/src/fswatch.cpp:177
+#: fswatch/src/fswatch.cpp:183
 msgid "Fire idle events.\n"
 msgstr "Fire idle events.\n"
 
-#: fswatch/src/fswatch.cpp:178
+#: fswatch/src/fswatch.cpp:184
 msgid "Show this message.\n"
 msgstr "Show this message.\n"
 
-#: fswatch/src/fswatch.cpp:179
+#: fswatch/src/fswatch.cpp:185
 msgid "Include paths matching REGEX.\n"
 msgstr "Include paths matching REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:180
+#: fswatch/src/fswatch.cpp:186
 msgid "Use case insensitive regular expressions.\n"
 msgstr "Use case insensitive regular expressions.\n"
 
-#: fswatch/src/fswatch.cpp:181
+#: fswatch/src/fswatch.cpp:187
 msgid "Set the latency.\n"
 msgstr "Set the latency.\n"
 
-#: fswatch/src/fswatch.cpp:183
+#: fswatch/src/fswatch.cpp:189
 msgid "Set the no defer flag in the monitor.\n"
 msgstr "Set the no defer flag in the monitor.\n"
 
-#: fswatch/src/fswatch.cpp:185
+#: fswatch/src/fswatch.cpp:191
 msgid "Follow symbolic links.\n"
 msgstr "Follow symbolic links.\n"
 
-#: fswatch/src/fswatch.cpp:186
+#: fswatch/src/fswatch.cpp:192
 msgid "List the available monitors.\n"
 msgstr "List the available monitors.\n"
 
-#: fswatch/src/fswatch.cpp:187
+#: fswatch/src/fswatch.cpp:193
 msgid "Use the specified monitor.\n"
 msgstr "Use the specified monitor.\n"
 
-#: fswatch/src/fswatch.cpp:189
+#: fswatch/src/fswatch.cpp:195
 msgid "Define the specified property.\n"
 msgstr "Define the specified property.\n"
 
-#: fswatch/src/fswatch.cpp:190
+#: fswatch/src/fswatch.cpp:196
 msgid "Print a numeric event mask.\n"
 msgstr "Print a numeric event mask.\n"
 
-#: fswatch/src/fswatch.cpp:191
+#: fswatch/src/fswatch.cpp:197
 msgid "Print a single message with the number of change events.\n"
 msgstr "Print a single message with the number of change events.\n"
 
-#: fswatch/src/fswatch.cpp:192
+#: fswatch/src/fswatch.cpp:198
+msgid "Do not descend into directories matching REGEX.\n"
+msgstr "Do not descend into directories matching REGEX.\n"
+
+#: fswatch/src/fswatch.cpp:199
 msgid "Recurse subdirectories.\n"
 msgstr "Recurse subdirectories.\n"
 
-#: fswatch/src/fswatch.cpp:193
+#: fswatch/src/fswatch.cpp:200
 msgid "Print the event timestamp.\n"
 msgstr "Print the event timestamp.\n"
 
-#: fswatch/src/fswatch.cpp:194
+#: fswatch/src/fswatch.cpp:201
 msgid "Print the event time as UTC time.\n"
 msgstr "Print the event time as UTC time.\n"
 
-#: fswatch/src/fswatch.cpp:195
+#: fswatch/src/fswatch.cpp:202
 msgid "Print the event flags.\n"
 msgstr "Print the event flags.\n"
 
-#: fswatch/src/fswatch.cpp:196
+#: fswatch/src/fswatch.cpp:203
 msgid "Filter the event by the specified type.\n"
 msgstr "Filter the event by the specified type.\n"
 
-#: fswatch/src/fswatch.cpp:198
+#: fswatch/src/fswatch.cpp:205
 msgid "Print event flags using the specified separator."
 msgstr "Print event flags using the specified separator."
 
-#: fswatch/src/fswatch.cpp:199
+#: fswatch/src/fswatch.cpp:206
 msgid "Print verbose output.\n"
 msgstr "Print verbose output.\n"
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid "Print the version of "
 msgstr "Print the version of "
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid " and exit.\n"
 msgstr " and exit.\n"
 
-#: fswatch/src/fswatch.cpp:238
+#: fswatch/src/fswatch.cpp:245
 msgid ""
 "Available monitors in this platform:\n"
 "\n"
@@ -219,7 +227,7 @@ msgstr ""
 "Available monitors in this platform:\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:241
+#: fswatch/src/fswatch.cpp:248
 msgid ""
 "\n"
 "See the man page for more information.\n"
@@ -229,95 +237,99 @@ msgstr ""
 "See the man page for more information.\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:243
+#: fswatch/src/fswatch.cpp:250
 msgid "Report bugs to <"
 msgstr "Report bugs to <"
 
-#: fswatch/src/fswatch.cpp:244
+#: fswatch/src/fswatch.cpp:251
 msgid " home page: <"
 msgstr " home page: <"
 
-#: fswatch/src/fswatch.cpp:255
+#: fswatch/src/fswatch.cpp:262
 msgid "Executing termination handler.\n"
 msgstr "Executing termination handler.\n"
 
-#: fswatch/src/fswatch.cpp:306
+#: fswatch/src/fswatch.cpp:325
+msgid "Invalid filter mode: "
+msgstr "Invalid filter mode: "
+
+#: fswatch/src/fswatch.cpp:333
 #: libfswatch/src/libfswatch/c++/windows_monitor.cpp:208
 msgid "Invalid value: "
 msgstr "Invalid value: "
 
-#: fswatch/src/fswatch.cpp:312
+#: fswatch/src/fswatch.cpp:339
 msgid "Value out of range: "
 msgstr "Value out of range: "
 
-#: fswatch/src/fswatch.cpp:328
+#: fswatch/src/fswatch.cpp:355
 msgid "SIGTERM handler registered.\n"
 msgstr "SIGTERM handler registered.\n"
 
-#: fswatch/src/fswatch.cpp:332
+#: fswatch/src/fswatch.cpp:359
 msgid "SIGTERM handler registration failed."
 msgstr "SIGTERM handler registration failed."
 
-#: fswatch/src/fswatch.cpp:337
+#: fswatch/src/fswatch.cpp:364
 msgid "SIGABRT handler registered.\n"
 msgstr "SIGABRT handler registered.\n"
 
-#: fswatch/src/fswatch.cpp:341
+#: fswatch/src/fswatch.cpp:368
 msgid "SIGABRT handler registration failed."
 msgstr "SIGABRT handler registration failed."
 
-#: fswatch/src/fswatch.cpp:346
+#: fswatch/src/fswatch.cpp:373
 msgid "SIGINT handler registered.\n"
 msgstr "SIGINT handler registered.\n"
 
-#: fswatch/src/fswatch.cpp:350
+#: fswatch/src/fswatch.cpp:377
 msgid "SIGINT handler registration failed"
 msgstr "SIGINT handler registration failed"
 
-#: fswatch/src/fswatch.cpp:372
+#: fswatch/src/fswatch.cpp:399
 msgid "<date format error>"
 msgstr "<date format error>"
 
-#: fswatch/src/fswatch.cpp:476
+#: fswatch/src/fswatch.cpp:503
 #, c-format
 msgid "Adding path: %s\n"
 msgstr "Adding path: %s\n"
 
-#: fswatch/src/fswatch.cpp:509
+#: fswatch/src/fswatch.cpp:542
 msgid "Invalid filter: "
 msgstr "Invalid filter: "
 
-#: fswatch/src/fswatch.cpp:751
+#: fswatch/src/fswatch.cpp:799
 msgid ""
 "--format is incompatible with any other format option such as -t and -x."
 msgstr ""
 "--format is incompatible with any other format option such as -t and -x."
 
-#: fswatch/src/fswatch.cpp:759
+#: fswatch/src/fswatch.cpp:807
 msgid "--format is incompatible with -o."
 msgstr "--format is incompatible with -o."
 
-#: fswatch/src/fswatch.cpp:774
+#: fswatch/src/fswatch.cpp:822
 msgid "Invalid format."
 msgstr "Invalid format."
 
-#: fswatch/src/fswatch.cpp:801
+#: fswatch/src/fswatch.cpp:849
 msgid "Invalid property format."
 msgstr "Invalid property format."
 
-#: fswatch/src/fswatch.cpp:911
+#: fswatch/src/fswatch.cpp:959
 msgid "Invalid number of arguments."
 msgstr "Invalid number of arguments."
 
-#: fswatch/src/fswatch.cpp:917
+#: fswatch/src/fswatch.cpp:965
 msgid "Invalid monitor name."
 msgstr "Invalid monitor name."
 
-#: fswatch/src/fswatch.cpp:949
+#: fswatch/src/fswatch.cpp:997
 msgid "An error occurred and the program will be terminated.\n"
 msgstr "An error occurred and the program will be terminated.\n"
 
-#: fswatch/src/fswatch.cpp:956
+#: fswatch/src/fswatch.cpp:1004
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "An unknown error occurred and the program will be terminated.\n"
 
@@ -361,17 +373,17 @@ msgstr "fanotify added: %s\n"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Synthetic event: processing directory: %s\n"
@@ -411,25 +423,25 @@ msgstr "Allocating fen_info.\n"
 msgid "Cannot allocate memory"
 msgstr "Cannot allocate memory"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:308
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:309
 #, c-format
 msgid "%s cannot be found. Will retry later.\n"
 msgstr "%s cannot be found. Will retry later.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:332
 msgid "Processing deleted descriptors.\n"
 msgstr "Processing deleted descriptors.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:353
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:354
 msgid "Rescanning pending descriptors.\n"
 msgstr "Rescanning pending descriptors.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:359
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:360
 #, c-format
 msgid "Rescanning %s.\n"
 msgstr "Rescanning %s.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:399
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:400
 msgid "Event from unexpected source"
 msgstr "Event from unexpected source"
 
@@ -504,23 +516,23 @@ msgstr "Removing: "
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 
@@ -529,19 +541,19 @@ msgstr "read() on inotify descriptor returned -1."
 msgid "Cannot open %s"
 msgstr "Cannot open %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:280
 msgid "kqueue already running."
 msgstr "kqueue already running."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:287
 msgid "kqueue failed."
 msgstr "kqueue failed."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:313
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent returned -1, invalid event number."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:332
 msgid "Event with EV_ERROR"
 msgstr "Event with EV_ERROR"
 
@@ -554,35 +566,40 @@ msgid "Latency cannot be negative."
 msgstr "Latency cannot be negative."
 
 #: libfswatch/src/libfswatch/c++/monitor.cpp:131
+#: libfswatch/src/libfswatch/c++/monitor.cpp:152
 #, c-format
 msgid "An error occurred during the compilation of %s"
 msgstr "An error occurred during the compilation of %s"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:221
+#: libfswatch/src/libfswatch/c++/monitor.cpp:198
+msgid "Unknown filter mode."
+msgstr "Unknown filter mode."
+
+#: libfswatch/src/libfswatch/c++/monitor.cpp:300
 msgid "Callback argument cannot be null."
 msgstr "Callback argument cannot be null."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:223
+#: libfswatch/src/libfswatch/c++/monitor.cpp:302
 msgid "Inactivity notification thread: starting\n"
 msgstr "Inactivity notification thread: starting\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:258
+#: libfswatch/src/libfswatch/c++/monitor.cpp:337
 msgid "Inactivity notification thread: exiting\n"
 msgstr "Inactivity notification thread: exiting\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:280
+#: libfswatch/src/libfswatch/c++/monitor.cpp:359
 msgid "Inactivity notification thread: joining\n"
 msgstr "Inactivity notification thread: joining\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/monitor.cpp:376
 msgid "Stopping the monitor.\n"
 msgstr "Stopping the monitor.\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:325
+#: libfswatch/src/libfswatch/c++/monitor.cpp:404
 msgid "Event queue overflow."
 msgstr "Event queue overflow."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:405
+#: libfswatch/src/libfswatch/c++/monitor.cpp:484
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notifying events #: %d.\n"
@@ -608,7 +625,7 @@ msgstr "Cannot lstat %s (not implemented on Windows)"
 msgid "Cannot lstat %s"
 msgstr "Cannot lstat %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:230
 msgid "Done scanning.\n"
 msgstr "Done scanning.\n"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-28 21:41+0200\n"
+"POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: fswatch/src/fswatch.cpp:147
+#: fswatch/src/fswatch.cpp:151
 msgid ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
@@ -25,75 +25,79 @@ msgstr ""
 "Licencia GPLv3+: GNU GPL versión 3 o sucesiva <http://gnu.org/licenses/"
 "gpl.html>.\n"
 
-#: fswatch/src/fswatch.cpp:148
+#: fswatch/src/fswatch.cpp:152
 msgid "This is free software: you are free to change and redistribute it.\n"
 msgstr "Éste es software libre: estás libre de cambiarlo y redistribuirlo.\n"
 
-#: fswatch/src/fswatch.cpp:149
+#: fswatch/src/fswatch.cpp:153
 msgid "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr "No hay NINGUNA GARANTÍA, en los límites permitidos por la ley.\n"
 
-#: fswatch/src/fswatch.cpp:151
+#: fswatch/src/fswatch.cpp:155
 msgid "Written by Enrico M. Crisostomo."
 msgstr "Escrito por Enrico M. Crisostomo."
 
-#: fswatch/src/fswatch.cpp:159 fswatch/src/fswatch.cpp:206
+#: fswatch/src/fswatch.cpp:163 fswatch/src/fswatch.cpp:213
 msgid "Usage:\n"
 msgstr "Uso:\n"
 
-#: fswatch/src/fswatch.cpp:160
+#: fswatch/src/fswatch.cpp:164
 msgid " [OPTION] ... path ...\n"
 msgstr " [OPCIÓN] ... ruta ...\n"
 
-#: fswatch/src/fswatch.cpp:162 fswatch/src/fswatch.cpp:209
+#: fswatch/src/fswatch.cpp:166 fswatch/src/fswatch.cpp:216
 msgid "Options:\n"
 msgstr "Opciones:\n"
 
-#: fswatch/src/fswatch.cpp:163
+#: fswatch/src/fswatch.cpp:167
 msgid "Use the ASCII NUL character (0) as line separator.\n"
 msgstr "Usa el carácter ASCII NUL (0) como separador de línea.\n"
 
-#: fswatch/src/fswatch.cpp:164
+#: fswatch/src/fswatch.cpp:168
 msgid "Exit fswatch after the first set of events is received.\n"
 msgstr "Sal de fswatch después de recibir el primer conjunto de eventos.\n"
 
-#: fswatch/src/fswatch.cpp:165
+#: fswatch/src/fswatch.cpp:169
 msgid "Allow a monitor to overflow and report it as a change event.\n"
 msgstr "Permite a un monitor desbordar y comunicarlo como evento de cambio.\n"
 
-#: fswatch/src/fswatch.cpp:166
+#: fswatch/src/fswatch.cpp:170
 msgid "Print a marker at the end of every batch.\n"
 msgstr "Muestra un marcador al final de cada batch.\n"
 
-#: fswatch/src/fswatch.cpp:167
+#: fswatch/src/fswatch.cpp:171
 msgid "Watch file accesses.\n"
 msgstr "Observa accesos a ficheros.\n"
 
-#: fswatch/src/fswatch.cpp:168
+#: fswatch/src/fswatch.cpp:172
 msgid "Bubble events with the same timestamp and path.\n"
 msgstr "Agrupa los eventos con la misma marca de tiempo y ruta.\n"
 
-#: fswatch/src/fswatch.cpp:169
+#: fswatch/src/fswatch.cpp:173
 msgid "Watch directories only.\n"
 msgstr "Observa solo carpetas.\n"
 
-#: fswatch/src/fswatch.cpp:170
+#: fswatch/src/fswatch.cpp:174
 msgid "Exclude paths matching REGEX.\n"
 msgstr "Excluye rutas que satisfacen a REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:171
+#: fswatch/src/fswatch.cpp:175
 msgid "Use extended regular expressions.\n"
 msgstr "Usa expresiones regulares extendidas.\n"
 
-#: fswatch/src/fswatch.cpp:173
+#: fswatch/src/fswatch.cpp:177
 msgid "Load filters from file."
 msgstr "Carga filtros desde un fichero."
 
-#: fswatch/src/fswatch.cpp:174
+#: fswatch/src/fswatch.cpp:179
+msgid "Set filter mode: legacy or conjunctive."
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:180
 msgid "Use the specified record format."
 msgstr "Usa el formato de registro especificado."
 
-#: fswatch/src/fswatch.cpp:175
+#: fswatch/src/fswatch.cpp:181
 msgid ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
@@ -101,97 +105,101 @@ msgstr ""
 "Directivas: %p ruta, %f indicadores, %t hora, %c correlación, %K tipo de id "
 "de proceso, %P id de proceso."
 
-#: fswatch/src/fswatch.cpp:176
+#: fswatch/src/fswatch.cpp:182
 msgid "Print the event time using the specified format.\n"
 msgstr ""
 "Muestra el marcador de tiempo del evento usando el formato especificado.\n"
 
-#: fswatch/src/fswatch.cpp:177
+#: fswatch/src/fswatch.cpp:183
 msgid "Fire idle events.\n"
 msgstr "Disparando evento de inactividad.\n"
 
-#: fswatch/src/fswatch.cpp:178
+#: fswatch/src/fswatch.cpp:184
 msgid "Show this message.\n"
 msgstr "Enseña este mensaje.\n"
 
-#: fswatch/src/fswatch.cpp:179
+#: fswatch/src/fswatch.cpp:185
 msgid "Include paths matching REGEX.\n"
 msgstr "Incluye rutas que satisfacen a REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:180
+#: fswatch/src/fswatch.cpp:186
 msgid "Use case insensitive regular expressions.\n"
 msgstr "Usa expresiones regulares no sensibles a mayúsculas.\n"
 
-#: fswatch/src/fswatch.cpp:181
+#: fswatch/src/fswatch.cpp:187
 msgid "Set the latency.\n"
 msgstr "Establece la latencia.\n"
 
-#: fswatch/src/fswatch.cpp:183
+#: fswatch/src/fswatch.cpp:189
 msgid "Set the no defer flag in the monitor.\n"
 msgstr "Establece el indicador no defer en el monitor.\n"
 
-#: fswatch/src/fswatch.cpp:185
+#: fswatch/src/fswatch.cpp:191
 msgid "Follow symbolic links.\n"
 msgstr "Sigue a los enlaces simbólicos.\n"
 
-#: fswatch/src/fswatch.cpp:186
+#: fswatch/src/fswatch.cpp:192
 msgid "List the available monitors.\n"
 msgstr "Muestra la lista de los monitors disponibles.\n"
 
-#: fswatch/src/fswatch.cpp:187
+#: fswatch/src/fswatch.cpp:193
 msgid "Use the specified monitor.\n"
 msgstr "Usa el monitor especificado.\n"
 
-#: fswatch/src/fswatch.cpp:189
+#: fswatch/src/fswatch.cpp:195
 msgid "Define the specified property.\n"
 msgstr "Define la propiedad especificada.\n"
 
-#: fswatch/src/fswatch.cpp:190
+#: fswatch/src/fswatch.cpp:196
 msgid "Print a numeric event mask.\n"
 msgstr "Muestra una máscara de evento numérica.\n"
 
-#: fswatch/src/fswatch.cpp:191
+#: fswatch/src/fswatch.cpp:197
 msgid "Print a single message with the number of change events.\n"
 msgstr "Muestra un único mensaje con el número de eventos de cambio.\n"
 
-#: fswatch/src/fswatch.cpp:192
+#: fswatch/src/fswatch.cpp:198
+msgid "Do not descend into directories matching REGEX.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:199
 msgid "Recurse subdirectories.\n"
 msgstr "Procesa recursivamente a las carpetas.\n"
 
-#: fswatch/src/fswatch.cpp:193
+#: fswatch/src/fswatch.cpp:200
 msgid "Print the event timestamp.\n"
 msgstr "Muestra el marcador de tiempo del evento.\n"
 
-#: fswatch/src/fswatch.cpp:194
+#: fswatch/src/fswatch.cpp:201
 msgid "Print the event time as UTC time.\n"
 msgstr "Muestra el marcador de tiempo en formato UTC.\n"
 
-#: fswatch/src/fswatch.cpp:195
+#: fswatch/src/fswatch.cpp:202
 msgid "Print the event flags.\n"
 msgstr "Muestra a los flags de evento.\n"
 
-#: fswatch/src/fswatch.cpp:196
+#: fswatch/src/fswatch.cpp:203
 msgid "Filter the event by the specified type.\n"
 msgstr "Filtra eventos del tipo especificado.\n"
 
-#: fswatch/src/fswatch.cpp:198
+#: fswatch/src/fswatch.cpp:205
 msgid "Print event flags using the specified separator."
 msgstr ""
 "Muestra el marcador de tiempo del evento usando el formato especificado."
 
-#: fswatch/src/fswatch.cpp:199
+#: fswatch/src/fswatch.cpp:206
 msgid "Print verbose output.\n"
 msgstr "Muestra mensajes detallados.\n"
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid "Print the version of "
 msgstr "Muestra la versión de "
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid " and exit.\n"
 msgstr " y sal.\n"
 
-#: fswatch/src/fswatch.cpp:238
+#: fswatch/src/fswatch.cpp:245
 msgid ""
 "Available monitors in this platform:\n"
 "\n"
@@ -199,7 +207,7 @@ msgstr ""
 "Monitors disponibles en esta plataforma:\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:241
+#: fswatch/src/fswatch.cpp:248
 msgid ""
 "\n"
 "See the man page for more information.\n"
@@ -209,95 +217,101 @@ msgstr ""
 "Consulta a la página man para más informaciones.\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:243
+#: fswatch/src/fswatch.cpp:250
 msgid "Report bugs to <"
 msgstr "Envía bugs a <"
 
-#: fswatch/src/fswatch.cpp:244
+#: fswatch/src/fswatch.cpp:251
 msgid " home page: <"
 msgstr " home page: <"
 
-#: fswatch/src/fswatch.cpp:255
+#: fswatch/src/fswatch.cpp:262
 msgid "Executing termination handler.\n"
 msgstr "Ejecutando el manejador de terminación.\n"
 
-#: fswatch/src/fswatch.cpp:306
+#: fswatch/src/fswatch.cpp:325
+#, fuzzy
+#| msgid "Invalid filter: "
+msgid "Invalid filter mode: "
+msgstr "Filtro inválido: "
+
+#: fswatch/src/fswatch.cpp:333
 #: libfswatch/src/libfswatch/c++/windows_monitor.cpp:208
 msgid "Invalid value: "
 msgstr "Valor inválido: "
 
-#: fswatch/src/fswatch.cpp:312
+#: fswatch/src/fswatch.cpp:339
 msgid "Value out of range: "
 msgstr "Valor fuera de rango: "
 
-#: fswatch/src/fswatch.cpp:328
+#: fswatch/src/fswatch.cpp:355
 msgid "SIGTERM handler registered.\n"
 msgstr "Gestor de SIGTERM registrado.\n"
 
-#: fswatch/src/fswatch.cpp:332
+#: fswatch/src/fswatch.cpp:359
 msgid "SIGTERM handler registration failed."
 msgstr "Registración del gestor de SIGTERM fallada."
 
-#: fswatch/src/fswatch.cpp:337
+#: fswatch/src/fswatch.cpp:364
 msgid "SIGABRT handler registered.\n"
 msgstr "Gestor de SIGABRT registrado.\n"
 
-#: fswatch/src/fswatch.cpp:341
+#: fswatch/src/fswatch.cpp:368
 msgid "SIGABRT handler registration failed."
 msgstr "Registración del gestor de SIGABRT fallada."
 
-#: fswatch/src/fswatch.cpp:346
+#: fswatch/src/fswatch.cpp:373
 msgid "SIGINT handler registered.\n"
 msgstr "Gestor de SIGINT registrado.\n"
 
-#: fswatch/src/fswatch.cpp:350
+#: fswatch/src/fswatch.cpp:377
 msgid "SIGINT handler registration failed"
 msgstr "Registración del gestor de SIGINT fallada"
 
-#: fswatch/src/fswatch.cpp:372
+#: fswatch/src/fswatch.cpp:399
 msgid "<date format error>"
 msgstr "<formato de data erróneo>"
 
-#: fswatch/src/fswatch.cpp:476
+#: fswatch/src/fswatch.cpp:503
 #, c-format
 msgid "Adding path: %s\n"
 msgstr "Añadiendo ruta: %s\n"
 
-#: fswatch/src/fswatch.cpp:509
+#: fswatch/src/fswatch.cpp:542
 msgid "Invalid filter: "
 msgstr "Filtro inválido: "
 
-#: fswatch/src/fswatch.cpp:751
+#: fswatch/src/fswatch.cpp:799
 msgid ""
 "--format is incompatible with any other format option such as -t and -x."
 msgstr ""
 "--format no es compatible con otras opciones de formato tales como -t y -x."
 
-#: fswatch/src/fswatch.cpp:759
+#: fswatch/src/fswatch.cpp:807
 msgid "--format is incompatible with -o."
 msgstr "--format no es compatible con -o."
 
-#: fswatch/src/fswatch.cpp:774
+#: fswatch/src/fswatch.cpp:822
 msgid "Invalid format."
 msgstr "Nombre de monitor inválido."
 
-#: fswatch/src/fswatch.cpp:801
+#: fswatch/src/fswatch.cpp:849
 msgid "Invalid property format."
 msgstr "Formato de propiedad inválido."
 
-#: fswatch/src/fswatch.cpp:911
+#: fswatch/src/fswatch.cpp:959
 msgid "Invalid number of arguments."
 msgstr "Número de argumentos inválidos."
 
-#: fswatch/src/fswatch.cpp:917
+#: fswatch/src/fswatch.cpp:965
 msgid "Invalid monitor name."
 msgstr "Nombre de monitor inválido."
 
-#: fswatch/src/fswatch.cpp:949
+#: fswatch/src/fswatch.cpp:997
 msgid "An error occurred and the program will be terminated.\n"
 msgstr "Ha ocurrido un error y el programa terminará.\n"
 
-#: fswatch/src/fswatch.cpp:956
+#: fswatch/src/fswatch.cpp:1004
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "Ha ocurrido un error desconocido y el programa terminará.\n"
 
@@ -342,17 +356,17 @@ msgstr "fanotify añadido: %s\n"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Error del sistema de ficheros: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Evento sintético: procesando carpeta: %s\n"
@@ -392,25 +406,25 @@ msgstr "Reservando memoria para fen_info.\n"
 msgid "Cannot allocate memory"
 msgstr "No se puede reservar memoria"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:308
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:309
 #, c-format
 msgid "%s cannot be found. Will retry later.\n"
 msgstr "%s no puede encontrarse. Se reintentará más tarde.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:332
 msgid "Processing deleted descriptors.\n"
 msgstr "Procesando descriptores eliminados.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:353
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:354
 msgid "Rescanning pending descriptors.\n"
 msgstr "Rastreando descriptores pendientes.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:359
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:360
 #, c-format
 msgid "Rescanning %s.\n"
 msgstr "Rastreando %s.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:399
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:400
 msgid "Event from unexpected source"
 msgstr "Evento de fuente inesperada"
 
@@ -485,23 +499,23 @@ msgstr "Eliminando: "
 msgid "Added: "
 msgstr "Añadiendo: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
 msgid "Generic event: "
 msgstr "Evento genérico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
 msgid "Removed: "
 msgstr "Eliminado: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
 msgid "Number of records: "
 msgstr "Numero de registros: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sobre el descriptor inotify leyó 0 registros."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sobre le descriptor inotify devolvió -1."
 
@@ -510,19 +524,19 @@ msgstr "read() sobre le descriptor inotify devolvió -1."
 msgid "Cannot open %s"
 msgstr "No se puede abrir %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:280
 msgid "kqueue already running."
 msgstr "kqueue ya está ejecutándose."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:287
 msgid "kqueue failed."
 msgstr "kqueue falló."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:313
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent devolvió -1, numero de evento inválido."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:332
 msgid "Event with EV_ERROR"
 msgstr "Evento con EV_ERROR"
 
@@ -535,35 +549,42 @@ msgid "Latency cannot be negative."
 msgstr "La latencia no puede ser negativa."
 
 #: libfswatch/src/libfswatch/c++/monitor.cpp:131
+#: libfswatch/src/libfswatch/c++/monitor.cpp:152
 #, c-format
 msgid "An error occurred during the compilation of %s"
 msgstr "Un error ocurrió durante la compilación de %s"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:221
+#: libfswatch/src/libfswatch/c++/monitor.cpp:198
+#, fuzzy
+#| msgid "Unknown filter type: "
+msgid "Unknown filter mode."
+msgstr "Tipo filtro desconocido: "
+
+#: libfswatch/src/libfswatch/c++/monitor.cpp:300
 msgid "Callback argument cannot be null."
 msgstr "El callback no puede ser null."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:223
+#: libfswatch/src/libfswatch/c++/monitor.cpp:302
 msgid "Inactivity notification thread: starting\n"
 msgstr "Thread para notificación de inactividad: arrancando\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:258
+#: libfswatch/src/libfswatch/c++/monitor.cpp:337
 msgid "Inactivity notification thread: exiting\n"
 msgstr "Thread para notificación de inactividad: saliendo\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:280
+#: libfswatch/src/libfswatch/c++/monitor.cpp:359
 msgid "Inactivity notification thread: joining\n"
 msgstr "Thread para notificación de inactividad: esperando\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/monitor.cpp:376
 msgid "Stopping the monitor.\n"
 msgstr "Parando el monitor...\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:325
+#: libfswatch/src/libfswatch/c++/monitor.cpp:404
 msgid "Event queue overflow."
 msgstr "Cola de eventos saturada."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:405
+#: libfswatch/src/libfswatch/c++/monitor.cpp:484
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notificando eventos #: %d.\n"
@@ -589,7 +610,7 @@ msgstr "No se puede hacer lstat() de %s (no implementado en Windows)"
 msgid "Cannot lstat %s"
 msgstr "No se puede hacer lstat() de %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:230
 msgid "Done scanning.\n"
 msgstr "Rastreo terminado.\n"
 

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.21.0-develop\n"
+"Project-Id-Version: fswatch 1.21.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-28 21:41+0200\n"
+"POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,275 +17,287 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: fswatch/src/fswatch.cpp:147
+#: fswatch/src/fswatch.cpp:151
 msgid ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:148
+#: fswatch/src/fswatch.cpp:152
 msgid "This is free software: you are free to change and redistribute it.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:149
+#: fswatch/src/fswatch.cpp:153
 msgid "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:151
+#: fswatch/src/fswatch.cpp:155
 msgid "Written by Enrico M. Crisostomo."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:159 fswatch/src/fswatch.cpp:206
+#: fswatch/src/fswatch.cpp:163 fswatch/src/fswatch.cpp:213
 msgid "Usage:\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:160
+#: fswatch/src/fswatch.cpp:164
 msgid " [OPTION] ... path ...\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:162 fswatch/src/fswatch.cpp:209
+#: fswatch/src/fswatch.cpp:166 fswatch/src/fswatch.cpp:216
 msgid "Options:\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:163
+#: fswatch/src/fswatch.cpp:167
 msgid "Use the ASCII NUL character (0) as line separator.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:164
+#: fswatch/src/fswatch.cpp:168
 msgid "Exit fswatch after the first set of events is received.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:165
+#: fswatch/src/fswatch.cpp:169
 msgid "Allow a monitor to overflow and report it as a change event.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:166
+#: fswatch/src/fswatch.cpp:170
 msgid "Print a marker at the end of every batch.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:167
+#: fswatch/src/fswatch.cpp:171
 msgid "Watch file accesses.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:168
+#: fswatch/src/fswatch.cpp:172
 msgid "Bubble events with the same timestamp and path.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:169
+#: fswatch/src/fswatch.cpp:173
 msgid "Watch directories only.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:170
+#: fswatch/src/fswatch.cpp:174
 msgid "Exclude paths matching REGEX.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:171
+#: fswatch/src/fswatch.cpp:175
 msgid "Use extended regular expressions.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:173
+#: fswatch/src/fswatch.cpp:177
 msgid "Load filters from file."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:174
+#: fswatch/src/fswatch.cpp:179
+msgid "Set filter mode: legacy or conjunctive."
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:180
 msgid "Use the specified record format."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:175
+#: fswatch/src/fswatch.cpp:181
 msgid ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:176
+#: fswatch/src/fswatch.cpp:182
 msgid "Print the event time using the specified format.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:177
+#: fswatch/src/fswatch.cpp:183
 msgid "Fire idle events.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:178
+#: fswatch/src/fswatch.cpp:184
 msgid "Show this message.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:179
+#: fswatch/src/fswatch.cpp:185
 msgid "Include paths matching REGEX.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:180
+#: fswatch/src/fswatch.cpp:186
 msgid "Use case insensitive regular expressions.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:181
+#: fswatch/src/fswatch.cpp:187
 msgid "Set the latency.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:183
+#: fswatch/src/fswatch.cpp:189
 msgid "Set the no defer flag in the monitor.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:185
+#: fswatch/src/fswatch.cpp:191
 msgid "Follow symbolic links.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:186
+#: fswatch/src/fswatch.cpp:192
 msgid "List the available monitors.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:187
+#: fswatch/src/fswatch.cpp:193
 msgid "Use the specified monitor.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:189
+#: fswatch/src/fswatch.cpp:195
 msgid "Define the specified property.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:190
+#: fswatch/src/fswatch.cpp:196
 msgid "Print a numeric event mask.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:191
+#: fswatch/src/fswatch.cpp:197
 msgid "Print a single message with the number of change events.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:192
-msgid "Recurse subdirectories.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:193
-msgid "Print the event timestamp.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:194
-msgid "Print the event time as UTC time.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:195
-msgid "Print the event flags.\n"
-msgstr ""
-
-#: fswatch/src/fswatch.cpp:196
-msgid "Filter the event by the specified type.\n"
-msgstr ""
-
 #: fswatch/src/fswatch.cpp:198
-msgid "Print event flags using the specified separator."
+msgid "Do not descend into directories matching REGEX.\n"
 msgstr ""
 
 #: fswatch/src/fswatch.cpp:199
+msgid "Recurse subdirectories.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:200
+msgid "Print the event timestamp.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:201
+msgid "Print the event time as UTC time.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:202
+msgid "Print the event flags.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:203
+msgid "Filter the event by the specified type.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:205
+msgid "Print event flags using the specified separator."
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:206
 msgid "Print verbose output.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid "Print the version of "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid " and exit.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:238
+#: fswatch/src/fswatch.cpp:245
 msgid ""
 "Available monitors in this platform:\n"
 "\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:241
+#: fswatch/src/fswatch.cpp:248
 msgid ""
 "\n"
 "See the man page for more information.\n"
 "\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:243
+#: fswatch/src/fswatch.cpp:250
 msgid "Report bugs to <"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:244
+#: fswatch/src/fswatch.cpp:251
 msgid " home page: <"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:255
+#: fswatch/src/fswatch.cpp:262
 msgid "Executing termination handler.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:306
+#: fswatch/src/fswatch.cpp:325
+msgid "Invalid filter mode: "
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:333
 #: libfswatch/src/libfswatch/c++/windows_monitor.cpp:208
 msgid "Invalid value: "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:312
+#: fswatch/src/fswatch.cpp:339
 msgid "Value out of range: "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:328
+#: fswatch/src/fswatch.cpp:355
 msgid "SIGTERM handler registered.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:332
+#: fswatch/src/fswatch.cpp:359
 msgid "SIGTERM handler registration failed."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:337
+#: fswatch/src/fswatch.cpp:364
 msgid "SIGABRT handler registered.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:341
+#: fswatch/src/fswatch.cpp:368
 msgid "SIGABRT handler registration failed."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:346
+#: fswatch/src/fswatch.cpp:373
 msgid "SIGINT handler registered.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:350
+#: fswatch/src/fswatch.cpp:377
 msgid "SIGINT handler registration failed"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:372
+#: fswatch/src/fswatch.cpp:399
 msgid "<date format error>"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:476
+#: fswatch/src/fswatch.cpp:503
 #, c-format
 msgid "Adding path: %s\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:509
+#: fswatch/src/fswatch.cpp:542
 msgid "Invalid filter: "
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:751
+#: fswatch/src/fswatch.cpp:799
 msgid ""
 "--format is incompatible with any other format option such as -t and -x."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:759
+#: fswatch/src/fswatch.cpp:807
 msgid "--format is incompatible with -o."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:774
+#: fswatch/src/fswatch.cpp:822
 msgid "Invalid format."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:801
+#: fswatch/src/fswatch.cpp:849
 msgid "Invalid property format."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:911
+#: fswatch/src/fswatch.cpp:959
 msgid "Invalid number of arguments."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:917
+#: fswatch/src/fswatch.cpp:965
 msgid "Invalid monitor name."
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:949
+#: fswatch/src/fswatch.cpp:997
 msgid "An error occurred and the program will be terminated.\n"
 msgstr ""
 
-#: fswatch/src/fswatch.cpp:956
+#: fswatch/src/fswatch.cpp:1004
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr ""
 
@@ -328,17 +340,17 @@ msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
 msgid "Filesystem error: %s"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr ""
@@ -378,25 +390,25 @@ msgstr ""
 msgid "Cannot allocate memory"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:308
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:309
 #, c-format
 msgid "%s cannot be found. Will retry later.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:332
 msgid "Processing deleted descriptors.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:353
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:354
 msgid "Rescanning pending descriptors.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:359
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:360
 #, c-format
 msgid "Rescanning %s.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:399
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:400
 msgid "Event from unexpected source"
 msgstr ""
 
@@ -471,23 +483,23 @@ msgstr ""
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 
@@ -496,19 +508,19 @@ msgstr ""
 msgid "Cannot open %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:280
 msgid "kqueue already running."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:287
 msgid "kqueue failed."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:313
 msgid "kevent returned -1, invalid event number."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:332
 msgid "Event with EV_ERROR"
 msgstr ""
 
@@ -521,35 +533,40 @@ msgid "Latency cannot be negative."
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/monitor.cpp:131
+#: libfswatch/src/libfswatch/c++/monitor.cpp:152
 #, c-format
 msgid "An error occurred during the compilation of %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:221
+#: libfswatch/src/libfswatch/c++/monitor.cpp:198
+msgid "Unknown filter mode."
+msgstr ""
+
+#: libfswatch/src/libfswatch/c++/monitor.cpp:300
 msgid "Callback argument cannot be null."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:223
+#: libfswatch/src/libfswatch/c++/monitor.cpp:302
 msgid "Inactivity notification thread: starting\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:258
+#: libfswatch/src/libfswatch/c++/monitor.cpp:337
 msgid "Inactivity notification thread: exiting\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:280
+#: libfswatch/src/libfswatch/c++/monitor.cpp:359
 msgid "Inactivity notification thread: joining\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/monitor.cpp:376
 msgid "Stopping the monitor.\n"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:325
+#: libfswatch/src/libfswatch/c++/monitor.cpp:404
 msgid "Event queue overflow."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:405
+#: libfswatch/src/libfswatch/c++/monitor.cpp:484
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr ""
@@ -575,7 +592,7 @@ msgstr ""
 msgid "Cannot lstat %s"
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:230
 msgid "Done scanning.\n"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-04-28 21:41+0200\n"
+"POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: 2018-05-02 17:29+0200\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: fswatch/src/fswatch.cpp:147
+#: fswatch/src/fswatch.cpp:151
 msgid ""
 "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/"
 "gpl.html>.\n"
@@ -25,78 +25,82 @@ msgstr ""
 "Licenza GLPv3+: GNU GPL versione 3 o successive <http://gnu.org/licenses/"
 "gpl.html>.\n"
 
-#: fswatch/src/fswatch.cpp:148
+#: fswatch/src/fswatch.cpp:152
 msgid "This is free software: you are free to change and redistribute it.\n"
 msgstr ""
 "Questo programma è free software: sei libero di modificarlo e "
 "ridistribuirlo.\n"
 
-#: fswatch/src/fswatch.cpp:149
+#: fswatch/src/fswatch.cpp:153
 msgid "There is NO WARRANTY, to the extent permitted by law.\n"
 msgstr "Non c'è NESSUNA GARANZIA, nei limiti permessi dalla legge.\n"
 
-#: fswatch/src/fswatch.cpp:151
+#: fswatch/src/fswatch.cpp:155
 msgid "Written by Enrico M. Crisostomo."
 msgstr "Scritto da Enrico M. Crisostomo."
 
-#: fswatch/src/fswatch.cpp:159 fswatch/src/fswatch.cpp:206
+#: fswatch/src/fswatch.cpp:163 fswatch/src/fswatch.cpp:213
 msgid "Usage:\n"
 msgstr "Sintassi:\n"
 
-#: fswatch/src/fswatch.cpp:160
+#: fswatch/src/fswatch.cpp:164
 msgid " [OPTION] ... path ...\n"
 msgstr " [OPZIONE] ... percorso ...\n"
 
-#: fswatch/src/fswatch.cpp:162 fswatch/src/fswatch.cpp:209
+#: fswatch/src/fswatch.cpp:166 fswatch/src/fswatch.cpp:216
 msgid "Options:\n"
 msgstr "Opzioni:\n"
 
-#: fswatch/src/fswatch.cpp:163
+#: fswatch/src/fswatch.cpp:167
 msgid "Use the ASCII NUL character (0) as line separator.\n"
 msgstr "Usa il carattere ASCII NUL (0) come separatore di linea.\n"
 
-#: fswatch/src/fswatch.cpp:164
+#: fswatch/src/fswatch.cpp:168
 msgid "Exit fswatch after the first set of events is received.\n"
 msgstr "Esci da fswatch dopo aver ricevuto il primo gruppo di eventi.\n"
 
-#: fswatch/src/fswatch.cpp:165
+#: fswatch/src/fswatch.cpp:169
 msgid "Allow a monitor to overflow and report it as a change event.\n"
 msgstr ""
 "Permette a un monitor di andare in overflow e segnalarlo con un evento.\n"
 
-#: fswatch/src/fswatch.cpp:166
+#: fswatch/src/fswatch.cpp:170
 msgid "Print a marker at the end of every batch.\n"
 msgstr "Inserisci un marcatore alla fine di ogni batch.\n"
 
-#: fswatch/src/fswatch.cpp:167
+#: fswatch/src/fswatch.cpp:171
 msgid "Watch file accesses.\n"
 msgstr "Osserva accesso a file.\n"
 
-#: fswatch/src/fswatch.cpp:168
+#: fswatch/src/fswatch.cpp:172
 msgid "Bubble events with the same timestamp and path.\n"
 msgstr "Raggruppa gli eventi con lo stesso timestamp e percorso.\n"
 
-#: fswatch/src/fswatch.cpp:169
+#: fswatch/src/fswatch.cpp:173
 msgid "Watch directories only.\n"
 msgstr "Osserva solo directories.\n"
 
-#: fswatch/src/fswatch.cpp:170
+#: fswatch/src/fswatch.cpp:174
 msgid "Exclude paths matching REGEX.\n"
 msgstr "Escludi i percorsi che soddisfano REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:171
+#: fswatch/src/fswatch.cpp:175
 msgid "Use extended regular expressions.\n"
 msgstr "Usa espressioni regolari estese.\n"
 
-#: fswatch/src/fswatch.cpp:173
+#: fswatch/src/fswatch.cpp:177
 msgid "Load filters from file."
 msgstr "Carica filtri da file."
 
-#: fswatch/src/fswatch.cpp:174
+#: fswatch/src/fswatch.cpp:179
+msgid "Set filter mode: legacy or conjunctive."
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:180
 msgid "Use the specified record format."
 msgstr "Usa il formato di record specificato."
 
-#: fswatch/src/fswatch.cpp:175
+#: fswatch/src/fswatch.cpp:181
 msgid ""
 "Directives: %p path, %f flags, %t time, %c correlation, %K process id kind, "
 "%P process id."
@@ -104,95 +108,99 @@ msgstr ""
 "Direttive: %p percorso, %f flag, %t ora, %c correlazione, %K tipo di id di "
 "processo, %P id di processo."
 
-#: fswatch/src/fswatch.cpp:176
+#: fswatch/src/fswatch.cpp:182
 msgid "Print the event time using the specified format.\n"
 msgstr "Formatta l'orario dell'evento usando il formato specificato.\n"
 
-#: fswatch/src/fswatch.cpp:177
+#: fswatch/src/fswatch.cpp:183
 msgid "Fire idle events.\n"
 msgstr "Notificando evento di inattività.\n"
 
-#: fswatch/src/fswatch.cpp:178
+#: fswatch/src/fswatch.cpp:184
 msgid "Show this message.\n"
 msgstr "Mostra questo messaggio.\n"
 
-#: fswatch/src/fswatch.cpp:179
+#: fswatch/src/fswatch.cpp:185
 msgid "Include paths matching REGEX.\n"
 msgstr "Includi i percorsi che soddisfano REGEX.\n"
 
-#: fswatch/src/fswatch.cpp:180
+#: fswatch/src/fswatch.cpp:186
 msgid "Use case insensitive regular expressions.\n"
 msgstr "Usa espressioni regolari non sensibili alle maiuscole.\n"
 
-#: fswatch/src/fswatch.cpp:181
+#: fswatch/src/fswatch.cpp:187
 msgid "Set the latency.\n"
 msgstr "Imposta la latenza.\n"
 
-#: fswatch/src/fswatch.cpp:183
+#: fswatch/src/fswatch.cpp:189
 msgid "Set the no defer flag in the monitor.\n"
 msgstr "Imposta il flag no defer nel monitor.\n"
 
-#: fswatch/src/fswatch.cpp:185
+#: fswatch/src/fswatch.cpp:191
 msgid "Follow symbolic links.\n"
 msgstr "Segui i link simbolici.\n"
 
-#: fswatch/src/fswatch.cpp:186
+#: fswatch/src/fswatch.cpp:192
 msgid "List the available monitors.\n"
 msgstr "Mostra la lista dei monitor disponibili.\n"
 
-#: fswatch/src/fswatch.cpp:187
+#: fswatch/src/fswatch.cpp:193
 msgid "Use the specified monitor.\n"
 msgstr "Usa il monitor specificato.\n"
 
-#: fswatch/src/fswatch.cpp:189
+#: fswatch/src/fswatch.cpp:195
 msgid "Define the specified property.\n"
 msgstr "Definisce la proprietà specificata.\n"
 
-#: fswatch/src/fswatch.cpp:190
+#: fswatch/src/fswatch.cpp:196
 msgid "Print a numeric event mask.\n"
 msgstr "Stampa una maschera di evento numerica.\n"
 
-#: fswatch/src/fswatch.cpp:191
+#: fswatch/src/fswatch.cpp:197
 msgid "Print a single message with the number of change events.\n"
 msgstr "Stampa un unico messaggio con il numero degli eventi di modifica.\n"
 
-#: fswatch/src/fswatch.cpp:192
+#: fswatch/src/fswatch.cpp:198
+msgid "Do not descend into directories matching REGEX.\n"
+msgstr ""
+
+#: fswatch/src/fswatch.cpp:199
 msgid "Recurse subdirectories.\n"
 msgstr "Analizza ricorsivamente le subdirectory.\n"
 
-#: fswatch/src/fswatch.cpp:193
+#: fswatch/src/fswatch.cpp:200
 msgid "Print the event timestamp.\n"
 msgstr "Stampa l'orario dell'evento.\n"
 
-#: fswatch/src/fswatch.cpp:194
+#: fswatch/src/fswatch.cpp:201
 msgid "Print the event time as UTC time.\n"
 msgstr "Stampa l'orario dell'evento nel formato UTC.\n"
 
-#: fswatch/src/fswatch.cpp:195
+#: fswatch/src/fswatch.cpp:202
 msgid "Print the event flags.\n"
 msgstr "Stampa i tipi di evento.\n"
 
-#: fswatch/src/fswatch.cpp:196
+#: fswatch/src/fswatch.cpp:203
 msgid "Filter the event by the specified type.\n"
 msgstr "Filtra gli eventi del tipo specificato.\n"
 
-#: fswatch/src/fswatch.cpp:198
+#: fswatch/src/fswatch.cpp:205
 msgid "Print event flags using the specified separator."
 msgstr "Formatta l'orario dell'evento usando il formato specificato."
 
-#: fswatch/src/fswatch.cpp:199
+#: fswatch/src/fswatch.cpp:206
 msgid "Print verbose output.\n"
 msgstr "Stampa informazioni addizionali.\n"
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid "Print the version of "
 msgstr "Stampa la versione di "
 
-#: fswatch/src/fswatch.cpp:200
+#: fswatch/src/fswatch.cpp:207
 msgid " and exit.\n"
 msgstr " ed esci.\n"
 
-#: fswatch/src/fswatch.cpp:238
+#: fswatch/src/fswatch.cpp:245
 msgid ""
 "Available monitors in this platform:\n"
 "\n"
@@ -200,7 +208,7 @@ msgstr ""
 "Monitors disponibili in questa piattaforma:\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:241
+#: fswatch/src/fswatch.cpp:248
 msgid ""
 "\n"
 "See the man page for more information.\n"
@@ -210,94 +218,100 @@ msgstr ""
 "Vedi la pagina man per avere ulteriori informazioni.\n"
 "\n"
 
-#: fswatch/src/fswatch.cpp:243
+#: fswatch/src/fswatch.cpp:250
 msgid "Report bugs to <"
 msgstr "Invia i bug a <"
 
-#: fswatch/src/fswatch.cpp:244
+#: fswatch/src/fswatch.cpp:251
 msgid " home page: <"
 msgstr " home page: <"
 
-#: fswatch/src/fswatch.cpp:255
+#: fswatch/src/fswatch.cpp:262
 msgid "Executing termination handler.\n"
 msgstr "Eseguendo il gestore di finalizzazione.\n"
 
-#: fswatch/src/fswatch.cpp:306
+#: fswatch/src/fswatch.cpp:325
+#, fuzzy
+#| msgid "Invalid filter: "
+msgid "Invalid filter mode: "
+msgstr "Filtro invalido: "
+
+#: fswatch/src/fswatch.cpp:333
 #: libfswatch/src/libfswatch/c++/windows_monitor.cpp:208
 msgid "Invalid value: "
 msgstr "Valore invalido: "
 
-#: fswatch/src/fswatch.cpp:312
+#: fswatch/src/fswatch.cpp:339
 msgid "Value out of range: "
 msgstr "Valore fuori rango: "
 
-#: fswatch/src/fswatch.cpp:328
+#: fswatch/src/fswatch.cpp:355
 msgid "SIGTERM handler registered.\n"
 msgstr "Gestore SIGTERM registrato.\n"
 
-#: fswatch/src/fswatch.cpp:332
+#: fswatch/src/fswatch.cpp:359
 msgid "SIGTERM handler registration failed."
 msgstr "Registrazione gestore SIGTERM fallita."
 
-#: fswatch/src/fswatch.cpp:337
+#: fswatch/src/fswatch.cpp:364
 msgid "SIGABRT handler registered.\n"
 msgstr "Gestore SIGABRT registrato.\n"
 
-#: fswatch/src/fswatch.cpp:341
+#: fswatch/src/fswatch.cpp:368
 msgid "SIGABRT handler registration failed."
 msgstr "Registrazione gestore SIGABRT fallita."
 
-#: fswatch/src/fswatch.cpp:346
+#: fswatch/src/fswatch.cpp:373
 msgid "SIGINT handler registered.\n"
 msgstr "Gestore SIGINT registrato.\n"
 
-#: fswatch/src/fswatch.cpp:350
+#: fswatch/src/fswatch.cpp:377
 msgid "SIGINT handler registration failed"
 msgstr "Registrazione gestore SIGINT fallita"
 
-#: fswatch/src/fswatch.cpp:372
+#: fswatch/src/fswatch.cpp:399
 msgid "<date format error>"
 msgstr "<errore nel formato della data>"
 
-#: fswatch/src/fswatch.cpp:476
+#: fswatch/src/fswatch.cpp:503
 #, c-format
 msgid "Adding path: %s\n"
 msgstr "Aggiungendo percorso: %s\n"
 
-#: fswatch/src/fswatch.cpp:509
+#: fswatch/src/fswatch.cpp:542
 msgid "Invalid filter: "
 msgstr "Filtro invalido: "
 
-#: fswatch/src/fswatch.cpp:751
+#: fswatch/src/fswatch.cpp:799
 msgid ""
 "--format is incompatible with any other format option such as -t and -x."
 msgstr "--format non è compatibile con altre opzioni di formato come -t e -x."
 
-#: fswatch/src/fswatch.cpp:759
+#: fswatch/src/fswatch.cpp:807
 msgid "--format is incompatible with -o."
 msgstr "--format non è cmopatibile con -o."
 
-#: fswatch/src/fswatch.cpp:774
+#: fswatch/src/fswatch.cpp:822
 msgid "Invalid format."
 msgstr "Nome del monitor invalido."
 
-#: fswatch/src/fswatch.cpp:801
+#: fswatch/src/fswatch.cpp:849
 msgid "Invalid property format."
 msgstr "Formato della proprietà invalido."
 
-#: fswatch/src/fswatch.cpp:911
+#: fswatch/src/fswatch.cpp:959
 msgid "Invalid number of arguments."
 msgstr "Numero di argomenti invalido."
 
-#: fswatch/src/fswatch.cpp:917
+#: fswatch/src/fswatch.cpp:965
 msgid "Invalid monitor name."
 msgstr "Nome del monitor invalido."
 
-#: fswatch/src/fswatch.cpp:949
+#: fswatch/src/fswatch.cpp:997
 msgid "An error occurred and the program will be terminated.\n"
 msgstr "Errore, il programma sarà terminato.\n"
 
-#: fswatch/src/fswatch.cpp:956
+#: fswatch/src/fswatch.cpp:1004
 msgid "An unknown error occurred and the program will be terminated.\n"
 msgstr "Errore sconosciuto, il programma sarà terminato.\n"
 
@@ -345,17 +359,17 @@ msgstr "fanotify aggiunto: %s\n"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:440
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:296
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:292
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:514
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:226
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:167
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
 msgid "Filesystem error: %s"
 msgstr "Errore del file system: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:500
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Evento sintetico: elaborazione directory: %s\n"
@@ -395,25 +409,25 @@ msgstr "Allocando fen_info.\n"
 msgid "Cannot allocate memory"
 msgstr "Non si può allocare memoria"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:308
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:309
 #, c-format
 msgid "%s cannot be found. Will retry later.\n"
 msgstr "%s non può essere trovato. Si riproverà più tardi.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:332
 msgid "Processing deleted descriptors.\n"
 msgstr "Processando descrittori eliminati.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:353
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:354
 msgid "Rescanning pending descriptors.\n"
 msgstr "Scansione dei descrittori in sospeso.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:359
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:360
 #, c-format
 msgid "Rescanning %s.\n"
 msgstr "Nuova scansione di %s.\n"
 
-#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:399
+#: libfswatch/src/libfswatch/c++/fen_monitor.cpp:400
 msgid "Event from unexpected source"
 msgstr "Evento da sorgente inattesa"
 
@@ -488,23 +502,23 @@ msgstr "Eliminando: "
 msgid "Added: "
 msgstr "Aggiunto: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:372
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
 msgid "Generic event: "
 msgstr "Evento generico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:464
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
 msgid "Removed: "
 msgstr "Eliminato: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:600
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
 msgid "Number of records: "
 msgstr "Numero di registri: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:606
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sul descrittore inotify ha trovato 0 registri."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:614
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sul descrittore inotify ha ritornato -1."
 
@@ -513,19 +527,19 @@ msgstr "read() sul descrittore inotify ha ritornato -1."
 msgid "Cannot open %s"
 msgstr "Non si può aprire %s"
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:279
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:280
 msgid "kqueue already running."
 msgstr "Si sta già eseguando kqueue."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:286
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:287
 msgid "kqueue failed."
 msgstr "kqueue ha fallito."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:312
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:313
 msgid "kevent returned -1, invalid event number."
 msgstr "kevent ha ritornato -1, numero di eventi invalido."
 
-#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:331
+#: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:332
 msgid "Event with EV_ERROR"
 msgstr "Evento con EV_ERROR"
 
@@ -538,35 +552,42 @@ msgid "Latency cannot be negative."
 msgstr "La latenza non può essere negativa."
 
 #: libfswatch/src/libfswatch/c++/monitor.cpp:131
+#: libfswatch/src/libfswatch/c++/monitor.cpp:152
 #, c-format
 msgid "An error occurred during the compilation of %s"
 msgstr "Si è prodotto un errore durante la compilazione di %s"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:221
+#: libfswatch/src/libfswatch/c++/monitor.cpp:198
+#, fuzzy
+#| msgid "Unknown filter type: "
+msgid "Unknown filter mode."
+msgstr "Tipo filtro sconosciuto: "
+
+#: libfswatch/src/libfswatch/c++/monitor.cpp:300
 msgid "Callback argument cannot be null."
 msgstr "Il callback non può essere nullo."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:223
+#: libfswatch/src/libfswatch/c++/monitor.cpp:302
 msgid "Inactivity notification thread: starting\n"
 msgstr "Thread per la notifica di inattività: partendo\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:258
+#: libfswatch/src/libfswatch/c++/monitor.cpp:337
 msgid "Inactivity notification thread: exiting\n"
 msgstr "Thread per la notifica di inattività: terminando\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:280
+#: libfswatch/src/libfswatch/c++/monitor.cpp:359
 msgid "Inactivity notification thread: joining\n"
 msgstr "Thread per la notifica di inattività: aspettando\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:297
+#: libfswatch/src/libfswatch/c++/monitor.cpp:376
 msgid "Stopping the monitor.\n"
 msgstr "Fermando il monitor...\n"
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:325
+#: libfswatch/src/libfswatch/c++/monitor.cpp:404
 msgid "Event queue overflow."
 msgstr "La coda degli eventi è andata in overflow."
 
-#: libfswatch/src/libfswatch/c++/monitor.cpp:405
+#: libfswatch/src/libfswatch/c++/monitor.cpp:484
 #, c-format
 msgid "Notifying events #: %d.\n"
 msgstr "Notificando eventi #: %d.\n"
@@ -592,7 +613,7 @@ msgstr "Non posso eseguire lstat() di %s (non implementato su Windows)"
 msgid "Cannot lstat %s"
 msgstr "Non posso eseguire lstat() di %s"
 
-#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:228
+#: libfswatch/src/libfswatch/c++/poll_monitor.cpp:230
 msgid "Done scanning.\n"
 msgstr "Scansione terminata.\n"
 


### PR DESCRIPTION
Prepare fswatch v. 1.21.0.

Release preparation includes:

- final version metadata for fswatch and libfswatch
- NEWS and NEWS.libfswatch updates for the filtering release work
- libfswatch libtool API version 15:0:0
- refreshed gettext catalogs

Validation:

- scripts/release/check.zsh 1.21.0
- CCACHE_DISABLE=1 ./configure
- make -C po update-po
- CCACHE_DISABLE=1 make -j2 distcheck
- scripts/release/check.zsh --release --require-dist 1.21.0
- scripts/release/check.zsh --release --notes /tmp/fswatch-1.21.0-release-notes.md 1.21.0