### PR TITLE
Bump version to 1.22.0-develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.21.0 LANGUAGES C CXX)
+project(fswatch VERSION 1.22.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "")
+set(VERSION_MODIFIER "-develop")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 NEWS
 ****
 
+New in 1.22.0-develop:
+
+
 New in 1.21.0:
 
   * CLI, Issues 104 and 273: Add --filter-mode=conjunctive.  In this mode,

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.21.0])
+m4_define([FSWATCH_VERSION], [1.22.0-develop])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.21.0])
+m4_define([LIBFSWATCH_VERSION], [1.22.0-develop])
 m4_define([LIBFSWATCH_API_VERSION], [15:0:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,7 +30,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.21.0\n"
+"Project-Id-Version: fswatch 1.22.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: 2026-05-09 20:17+0200\n"

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,7 +27,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.21.0\n"
+"Project-Id-Version: fswatch 1.22.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: 2026-05-09 20:17+0200\n"

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.21.0\n"
+"Project-Id-Version: fswatch 1.22.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-05-09 20:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Prepare master for the next development cycle after publishing fswatch v. 1.21.0.

Changes:

- set fswatch and libfswatch versions to 1.22.0-develop
- restore the CMake -develop version modifier
- add the top NEWS section for 1.22.0-develop
- refresh gettext catalog headers

Validation:

- scripts/release/check.zsh 1.22.0-develop
- ./autogen.sh
- CCACHE_DISABLE=1 CC=gcc CXX=g++ ./configure
- make -C po update-po