### PR TITLE
Fix child paths for inotify move events

### DIFF
--- a/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -327,7 +327,17 @@ namespace fsw
 
     if (!flags.empty())
     {
-      impl->events.emplace_back(impl->wd_to_path[event->wd], impl->curr_time, flags, event->cookie);
+      std::ostringstream filename_stream;
+      filename_stream << impl->wd_to_path[event->wd];
+
+      if ((event->mask & (IN_MOVED_FROM | IN_MOVED_TO)) &&
+          event->len > 0 && event->name[0] != '\0')
+      {
+        filename_stream << "/";
+        filename_stream << event->name;
+      }
+
+      impl->events.emplace_back(filename_stream.str(), impl->curr_time, flags, event->cookie);
     }
 
   }

--- a/test/inotify_basic_events.sh
+++ b/test/inotify_basic_events.sh
@@ -43,23 +43,50 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 TESTDIR="${WORKDIR}/watched"
-mkdir "${TESTDIR}"
+OUTSIDE_IN="${WORKDIR}/outside-in"
+OUTSIDE_OUT="${WORKDIR}/outside-out"
+SYMLINK_TARGET="${WORKDIR}/symlink-target"
+SYMLINK_ROOT="${WORKDIR}/watched-link"
+mkdir "${TESTDIR}" "${OUTSIDE_IN}" "${OUTSIDE_OUT}" "${SYMLINK_TARGET}"
+ln -s "${SYMLINK_TARGET}" "${SYMLINK_ROOT}"
 
-"${FSWATCH}" -m inotify_monitor -r --format '%p %f' "${TESTDIR}" \
+"${FSWATCH}" -m inotify_monitor -r --format '%p|%f|%c' \
+  "${TESTDIR}" "${SYMLINK_ROOT}" \
   > "${WORKDIR}/out.log" 2> "${WORKDIR}/err.log" &
 PID=$!
 
 sleep 1
 
 CREATE_FILE="${TESTDIR}/created.txt"
-MOVE_SOURCE="${TESTDIR}/move-source.txt"
-MOVE_TARGET="${TESTDIR}/move-target.txt"
+MOVE_IN_SOURCE="${OUTSIDE_IN}/move-in.txt"
+MOVE_IN_TARGET="${TESTDIR}/move-in.txt"
+DIR_MOVE_IN_SOURCE="${OUTSIDE_IN}/move-in-dir"
+DIR_MOVE_IN_TARGET="${TESTDIR}/move-in-dir"
+MOVE_OUT_SOURCE="${TESTDIR}/move-out.txt"
+MOVE_OUT_TARGET="${OUTSIDE_OUT}/move-out.txt"
+MOVE_SOURCE="${TESTDIR}/paired-from.txt"
+MOVE_TARGET="${TESTDIR}/paired-to.txt"
+REPLACEMENT_SOURCE="${TESTDIR}/replacement-source.txt"
+REPLACEMENT_TARGET="${TESTDIR}/replacement-target.txt"
+SYMLINK_SOURCE="${OUTSIDE_IN}/symlink-in.txt"
+SYMLINK_DESTINATION="${SYMLINK_TARGET}/symlink-in.txt"
 DELETE_FILE="${TESTDIR}/delete-me.txt"
 
 echo created > "${CREATE_FILE}"
 echo update >> "${CREATE_FILE}"
+echo move-in > "${MOVE_IN_SOURCE}"
+mv "${MOVE_IN_SOURCE}" "${MOVE_IN_TARGET}"
+mkdir "${DIR_MOVE_IN_SOURCE}"
+mv "${DIR_MOVE_IN_SOURCE}" "${DIR_MOVE_IN_TARGET}"
+echo move-out > "${MOVE_OUT_SOURCE}"
+mv "${MOVE_OUT_SOURCE}" "${MOVE_OUT_TARGET}"
 echo move > "${MOVE_SOURCE}"
 mv "${MOVE_SOURCE}" "${MOVE_TARGET}"
+echo original > "${REPLACEMENT_TARGET}"
+echo replacement > "${REPLACEMENT_SOURCE}"
+mv -f "${REPLACEMENT_SOURCE}" "${REPLACEMENT_TARGET}"
+echo symlink > "${SYMLINK_SOURCE}"
+mv "${SYMLINK_SOURCE}" "${SYMLINK_DESTINATION}"
 echo delete > "${DELETE_FILE}"
 rm "${DELETE_FILE}"
 
@@ -89,8 +116,47 @@ assert_event() {
   fi
 }
 
-assert_event 'created\.txt .*Created' 'file creation'
-assert_event 'created\.txt .*(Updated|CloseWrite)' 'file update'
-assert_event '/watched .*MovedFrom' 'rename source'
-assert_event '/watched .*MovedTo' 'rename target'
-assert_event 'delete-me\.txt .*Removed' 'file deletion'
+assert_event 'created\.txt\|.*Created' 'file creation'
+assert_event 'created\.txt\|.*(Updated|CloseWrite)' 'file update'
+assert_event '/watched/move-in\.txt\|.*MovedTo.*\|[1-9][0-9]*$' 'one-sided move-in'
+assert_event '/watched/move-in-dir\|.*MovedTo.*\|[1-9][0-9]*$' 'one-sided directory move-in'
+assert_event '/watched/move-out\.txt\|.*MovedFrom.*\|[1-9][0-9]*$' 'one-sided move-out'
+assert_event '/watched/paired-from\.txt\|.*MovedFrom.*\|[1-9][0-9]*$' 'paired rename source'
+assert_event '/watched/paired-to\.txt\|.*MovedTo.*\|[1-9][0-9]*$' 'paired rename target'
+assert_event '/watched/replacement-source\.txt\|.*MovedFrom.*\|[1-9][0-9]*$' 'replacement-by-rename source'
+assert_event '/watched/replacement-target\.txt\|.*MovedTo.*\|[1-9][0-9]*$' 'replacement-by-rename target'
+assert_event '/watched-link/symlink-in\.txt\|.*MovedTo.*\|[1-9][0-9]*$' 'symlinked watch root'
+assert_event 'delete-me\.txt\|.*Removed' 'file deletion'
+
+if ! awk -F '|' '
+  $1 ~ /\/watched\/move-in-dir$/ &&
+  $2 ~ /(^| )MovedTo( |$)/ &&
+  $2 ~ /(^| )IsDir( |$)/ &&
+  $3 ~ /^[1-9][0-9]*$/ { found = 1 }
+  END { exit !found }
+' "${WORKDIR}/out.log"; then
+  echo "missing complete one-sided directory move-in event" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  exit 1
+fi
+
+PAIRED_FROM_COOKIE=$(awk -F '|' '/\/watched\/paired-from\.txt\|.*MovedFrom/ { print $3; exit }' "${WORKDIR}/out.log")
+PAIRED_TO_COOKIE=$(awk -F '|' '/\/watched\/paired-to\.txt\|.*MovedTo/ { print $3; exit }' "${WORKDIR}/out.log")
+REPLACEMENT_FROM_COOKIE=$(awk -F '|' '/\/watched\/replacement-source\.txt\|.*MovedFrom/ { print $3; exit }' "${WORKDIR}/out.log")
+REPLACEMENT_TO_COOKIE=$(awk -F '|' '/\/watched\/replacement-target\.txt\|.*MovedTo/ { print $3; exit }' "${WORKDIR}/out.log")
+
+if [ -z "${PAIRED_FROM_COOKIE}" ] ||
+   [ "${PAIRED_FROM_COOKIE}" = 0 ] ||
+   [ "${PAIRED_FROM_COOKIE}" != "${PAIRED_TO_COOKIE}" ]; then
+  echo "inotify rename cookies do not match: from=${PAIRED_FROM_COOKIE}, to=${PAIRED_TO_COOKIE}" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  exit 1
+fi
+
+if [ -z "${REPLACEMENT_FROM_COOKIE}" ] ||
+   [ "${REPLACEMENT_FROM_COOKIE}" = 0 ] ||
+   [ "${REPLACEMENT_FROM_COOKIE}" != "${REPLACEMENT_TO_COOKIE}" ]; then
+  echo "inotify replacement cookies do not match: from=${REPLACEMENT_FROM_COOKIE}, to=${REPLACEMENT_TO_COOKIE}" >&2
+  sed -n '1,160p' "${WORKDIR}/out.log" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Append the kernel-provided child name for `IN_MOVED_FROM` and `IN_MOVED_TO`.
- Preserve the kernel rename-correlation cookie.
- Do not introduce an in-memory cookie-pairing cache.
- Leave non-move `IN_ISDIR` behavior unchanged.

## Regression coverage

- one-sided file move-in;
- one-sided directory move-in;
- one-sided file move-out;
- paired rename;
- replacement-by-rename;
- symlinked watch-root spelling;
- nonzero and matching cookies for paired events.

## Validation

- strengthened test failed against the unpatched implementation;
- CMake inotify suite: 16/16 passed;
- Autotools inotify suite: 16/16 passed;
- direct matrix passed with both builds;
- shell syntax validation passed;
- `git diff --check` passed.

Fixes #387.
