### PR TITLE
Bump v. 1.22.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(fswatch VERSION 1.22.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-develop")
+set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,14 @@
 NEWS
 ****
 
-New in 1.22.0-develop:
+New in 1.22.0:
+
+  * The release workflow now provides an experimental static Linux x86_64
+    archive.
+
+  * Bug fix, PR 388, Issue 387: On Linux, inotify MovedFrom and MovedTo events
+    now report the complete child path for one-sided moves and paired renames,
+    while preserving the kernel rename-correlation cookie.
 
 
 New in 1.21.0:

--- a/NEWS.libfswatch
+++ b/NEWS.libfswatch
@@ -1,6 +1,13 @@
 NEWS
 ****
 
+New in 1.22.0:
+
+  * Bug fix, PR 388, Issue 387: The inotify monitor now appends the
+    kernel-provided child name to MovedFrom and MovedTo event paths while
+    forwarding rename-correlation cookies unchanged.
+
+
 New in 1.21.0:
 
   * API, Issues 104 and 273: Add conjunctive path filter evaluation mode.  In

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.22.0-develop])
+m4_define([FSWATCH_VERSION], [1.22.0])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.22.0-develop])
-m4_define([LIBFSWATCH_API_VERSION], [15:0:0])
+m4_define([LIBFSWATCH_VERSION], [1.22.0])
+m4_define([LIBFSWATCH_API_VERSION], [15:1:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-05-09 20:17+0200\n"
+"POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: English\n"
@@ -342,7 +342,7 @@ msgstr ""
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
 #: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:525
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
@@ -350,7 +350,7 @@ msgid "Filesystem error: %s"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:511
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr ""
@@ -483,23 +483,23 @@ msgstr ""
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:383
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:611
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:617
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:625
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,10 +30,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.22.0-develop\n"
+"Project-Id-Version: fswatch 1.22.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-05-09 20:17+0200\n"
-"PO-Revision-Date: 2026-05-09 20:17+0200\n"
+"POT-Creation-Date: 2026-07-22 10:43+0200\n"
+"PO-Revision-Date: 2026-07-22 10:43+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@boldquot\n"
@@ -378,7 +378,7 @@ msgstr "fanotify added: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
 #: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:525
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
@@ -386,7 +386,7 @@ msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:511
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Synthetic event: processing directory: %s\n"
@@ -519,23 +519,23 @@ msgstr "Removing: "
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:383
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:611
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:617
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:625
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,10 +27,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.22.0-develop\n"
+"Project-Id-Version: fswatch 1.22.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-05-09 20:17+0200\n"
-"PO-Revision-Date: 2026-05-09 20:17+0200\n"
+"POT-Creation-Date: 2026-07-22 10:43+0200\n"
+"PO-Revision-Date: 2026-07-22 10:43+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en@quot\n"
@@ -375,7 +375,7 @@ msgstr "fanotify added: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
 #: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:525
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
@@ -383,7 +383,7 @@ msgid "Filesystem error: %s"
 msgstr "Filesystem error: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:511
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Synthetic event: processing directory: %s\n"
@@ -516,23 +516,23 @@ msgstr "Removing: "
 msgid "Added: "
 msgstr "Added: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:383
 msgid "Generic event: "
 msgstr "Generic event: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "Removed: "
 msgstr "Removed: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:611
 msgid "Number of records: "
 msgstr "Number of records: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:617
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() on inotify descriptor read 0 records."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:625
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() on inotify descriptor returned -1."
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-05-09 20:17+0200\n"
+"POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: 2017-10-29 14:04+0100\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -358,7 +358,7 @@ msgstr "fanotify añadido: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
 #: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:525
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
@@ -366,7 +366,7 @@ msgid "Filesystem error: %s"
 msgstr "Error del sistema de ficheros: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:511
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Evento sintético: procesando carpeta: %s\n"
@@ -499,23 +499,23 @@ msgstr "Eliminando: "
 msgid "Added: "
 msgstr "Añadiendo: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:383
 msgid "Generic event: "
 msgstr "Evento genérico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "Removed: "
 msgstr "Eliminado: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:611
 msgid "Number of records: "
 msgstr "Numero de registros: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:617
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sobre el descriptor inotify leyó 0 registros."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:625
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sobre le descriptor inotify devolvió -1."
 

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.22.0-develop\n"
+"Project-Id-Version: fswatch 1.22.0\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-05-09 20:17+0200\n"
+"POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -342,7 +342,7 @@ msgstr ""
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
 #: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:525
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
@@ -350,7 +350,7 @@ msgid "Filesystem error: %s"
 msgstr ""
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:511
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr ""
@@ -483,23 +483,23 @@ msgstr ""
 msgid "Added: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:383
 msgid "Generic event: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "Removed: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:611
 msgid "Number of records: "
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:617
 msgid "read() on inotify descriptor read 0 records."
 msgstr ""
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:625
 msgid "read() on inotify descriptor returned -1."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fswatch 1.11.3\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
-"POT-Creation-Date: 2026-05-09 20:17+0200\n"
+"POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: 2018-05-02 17:29+0200\n"
 "Last-Translator: Enrico Maria Crisostomo <enrico.m.crisostomo@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -361,7 +361,7 @@ msgstr "fanotify aggiunto: %s\n"
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:480
 #: libfswatch/src/libfswatch/c++/fen_monitor.cpp:297
 #: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:293
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:515
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:525
 #: libfswatch/src/libfswatch/c++/kqueue_monitor.cpp:227
 #: libfswatch/src/libfswatch/c++/poll_monitor.cpp:169
 #, c-format
@@ -369,7 +369,7 @@ msgid "Filesystem error: %s"
 msgstr "Errore del file system: %s"
 
 #: libfswatch/src/libfswatch/c++/fanotify_monitor.cpp:466
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:501
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:511
 #, c-format
 msgid "Synthetic event: processing directory: %s\n"
 msgstr "Evento sintetico: elaborazione directory: %s\n"
@@ -502,23 +502,23 @@ msgstr "Eliminando: "
 msgid "Added: "
 msgstr "Aggiunto: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:373
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:383
 msgid "Generic event: "
 msgstr "Evento generico: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:465
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:475
 msgid "Removed: "
 msgstr "Eliminato: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:601
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:611
 msgid "Number of records: "
 msgstr "Numero di registri: "
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:607
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:617
 msgid "read() on inotify descriptor read 0 records."
 msgstr "read() sul descrittore inotify ha trovato 0 registri."
 
-#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:615
+#: libfswatch/src/libfswatch/c++/inotify_monitor.cpp:625
 msgid "read() on inotify descriptor returned -1."
 msgstr "read() sul descrittore inotify ha ritornato -1."
 


### PR DESCRIPTION
## Summary

- Finalize fswatch and libfswatch at version `1.22.0`.
- Change `LIBFSWATCH_API_VERSION` from `15:0:0` to `15:1:0` for the implementation-only libfswatch change since 1.21.0.
- Add NEWS entries for the experimental static Linux x86_64 release archive and the inotify move-path correction from PR #388 / issue #387.
- Refresh gettext metadata for the final version and updated inotify source-line references.
- Keep public headers and API declarations unchanged.

## Gettext refresh

`po/en.po`, `po/en@boldquot.po`, `po/en@quot.po`, `po/es.po`, `po/it.po`, and `po/fswatch.pot` were regenerated.

The changes are limited to package-version headers, creation/revision timestamps, and source references shifted by the #387 implementation. No `msgid` or `msgstr` was added, removed, or changed.

## Validation

- `./autogen.sh` — passed.
- `CC=gcc CXX=g++ ./configure` — passed.
- `make -C po update-po` — passed.
- `scripts/release/test.zsh --distcheck` — passed, including its simulated release packaging test.
- `scripts/release/check.zsh 1.22.0` — passed; both package versions, CMake metadata, both NEWS headings, and Libtool API version were correct.
- `make -j distcheck` — passed; packaged test suite: 30/30 passed.
- `scripts/release/check.zsh --release --require-dist 1.22.0` — passed.
- `cmake -B build -DCMAKE_BUILD_TYPE=Release` — passed.
- `cmake --build build --config Release` — passed.
- `ctest --test-dir build -C Release --output-on-failure` — passed; 31/31 tests passed in the final host run.
- `make -j pdf` — passed.
- `test -f fswatch/doc/fswatch.pdf` — passed; generated output is a PDF 1.7 document.
- `git diff --check` — passed.

The generated `fswatch-1.22.0.tar.gz` contains 239 entries under the single top-level directory `fswatch-1.22.0/`. Its m4, configure, NEWS, gettext, and generated Texinfo version metadata all report final `1.22.0`, and the expected Autotools source, documentation, inotify implementation, regression test, and gettext files are present. No local build directory, release notes, PDF output, or Git metadata is included. The archive was validated locally only and was not uploaded.
