### PR TITLE
Bump version to 1.23.0-develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.22.0 LANGUAGES C CXX)
+project(fswatch VERSION 1.23.0 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "")
+set(VERSION_MODIFIER "-develop")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 NEWS
 ****
 
+New in 1.23.0-develop:
+
+
 New in 1.22.0:
 
   * The release workflow now provides an experimental static Linux x86_64

--- a/m4/fswatch_version.m4
+++ b/m4/fswatch_version.m4
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-m4_define([FSWATCH_VERSION], [1.22.0])
+m4_define([FSWATCH_VERSION], [1.23.0-develop])
 m4_define([FSWATCH_REVISION], [1])

--- a/m4/libfswatch_version.m4
+++ b/m4/libfswatch_version.m4
@@ -37,6 +37,6 @@
 #
 # Libtool documentation, 7.3 Updating library version information
 #
-m4_define([LIBFSWATCH_VERSION], [1.22.0])
+m4_define([LIBFSWATCH_VERSION], [1.23.0-develop])
 m4_define([LIBFSWATCH_API_VERSION], [15:1:0])
 m4_define([LIBFSWATCH_REVISION], [1])

--- a/po/en@boldquot.po
+++ b/po/en@boldquot.po
@@ -30,7 +30,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.22.0\n"
+"Project-Id-Version: fswatch 1.23.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: 2026-07-22 10:43+0200\n"

--- a/po/en@quot.po
+++ b/po/en@quot.po
@@ -27,7 +27,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.22.0\n"
+"Project-Id-Version: fswatch 1.23.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: 2026-07-22 10:43+0200\n"

--- a/po/fswatch.pot
+++ b/po/fswatch.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fswatch 1.22.0\n"
+"Project-Id-Version: fswatch 1.23.0-develop\n"
 "Report-Msgid-Bugs-To: enrico.m.crisostomo@gmail.com\n"
 "POT-Creation-Date: 2026-07-22 10:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
## Summary

- Open the fswatch 1.23.0 development cycle after publishing fswatch 1.22.0.
- Set `FSWATCH_VERSION` and `LIBFSWATCH_VERSION` to `1.23.0-develop`.
- Set the CMake project version to `1.23.0` and restore `VERSION_MODIFIER="-develop"`.
- Keep `LIBFSWATCH_API_VERSION=15:1:0` and the existing revision fields unchanged.
- Add an empty `New in 1.23.0-develop:` section above the preserved 1.22.0 history in `NEWS`.
- Leave `NEWS.libfswatch` unchanged, following the documented post-release policy and PR #384 precedent.
- Refresh gettext project-version headers without changing messages or translations.

## Validation

- `scripts/release/post-release.zsh 1.23.0` — dry run matched the documented plan.
- `scripts/release/post-release.zsh --apply 1.23.0` — applied the expected four metadata/NEWS edits.
- `./autogen.sh` — passed.
- `CC=gcc CXX=g++ ./configure` — passed on the authorized host after the sandbox ccache directory proved read-only.
- `make -C po update-po` — passed; translation counts and all message IDs/strings remained unchanged.
- `scripts/release/check.zsh 1.23.0-develop` — passed.
- `scripts/release/check.zsh --release 1.23.0-develop` — correctly rejected the development version.
- `git diff --check` — passed.
- `make -j check` — 30/30 tests passed.
- `cmake -S . -B <temporary-build> -DCMAKE_BUILD_TYPE=Release` — passed.
- `cmake --build <temporary-build> --config Release -j` — passed.
- `ctest --test-dir <temporary-build> -C Release --output-on-failure` — 31/31 tests passed.
- Both Autotools and CMake binaries report `fswatch 1.23.0-develop`.
- `scripts/release/test.zsh` — passed, including shell syntax, metadata, guard, dry-run, simulated release, notes, publication-dry-run, and post-release checks.

No release artifact, release metadata, tag, asset, or website content is changed by this PR.
